### PR TITLE
Real-currents ipfs integration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,77 @@
+name: Deploy to Gandi + IPFS
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install Quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Build Site (Quarto + Next.js)
+        run: npm run build
+
+      - name: Deploy to Gandi via Git
+        env:
+          GANDI_GIT_URL: ${{ secrets.GANDI_GIT_URL }}
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          git remote add gandi "$GANDI_GIT_URL" || true
+          git push gandi HEAD:main --force
+
+      - name: Install ipfs-car CLI
+        run: npm install -g ipfs-car
+
+      - name: Package Build as CAR
+        run: ipfs-car pack out --output deploy.car
+
+      - name: Upload CAR to IPFS (via Gandi Gateway)
+        id: ipfs_upload
+        env:
+          DEPLOY_SECRET: ${{ secrets.DEPLOY_SECRET }}
+        run: |
+          RESPONSE=$(curl -sSf -X POST https://www.real-currents.com/api/deploy \
+            -H "x-api-key: $DEPLOY_SECRET" \
+            -H "Content-Type: application/vnd.ipld.car" \
+            --data-binary @deploy.car)
+          echo "IPFS Response: $RESPONSE"
+
+          CID=$(node -e "const fs=require('node:fs');const payload=JSON.parse(fs.readFileSync(0,'utf8'));if(!payload.cid){process.exit(1);}process.stdout.write(payload.cid);" <<< "$RESPONSE")
+          echo "cid=$CID" >> "$GITHUB_OUTPUT"
+          echo "Deployed to IPFS: $CID"
+
+      - name: Update IPNS Pointer (xr-baseline-0)
+        env:
+          DEPLOY_SECRET: ${{ secrets.DEPLOY_SECRET }}
+          CID: ${{ steps.ipfs_upload.outputs.cid }}
+        run: |
+          curl -sSf -X POST https://www.real-currents.com/api/ipns/publish \
+            -H "x-api-key: $DEPLOY_SECRET" \
+            -H "Content-Type: application/json" \
+            -d "{\"key\": \"xr-baseline-0\", \"cid\": \"$CID\"}"
+
+          echo "IPNS updated: xr-baseline-0 -> $CID"
+
+      - name: Log Deployment
+        run: |
+          echo "✅ Live site updated at https://www.real-currents.com"
+          echo "✅ IPFS snapshot: https://www.real-currents.com/ipfs/${{ steps.ipfs_upload.outputs.cid }}"
+          echo "✅ IPNS stable link: https://www.real-currents.com/ipns/xr-baseline-0"

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-    "distDir": "out",
     "eslint": {
         "ignoreDuringBuilds": true,
     },
@@ -12,6 +11,10 @@ const nextConfig = {
     // ],
     "output": "export", // <=== enables static exports
     // "output": "standalone",
+    "trailingSlash": true,
+    "images": {
+        "unoptimized": true,
+    },
     "reactStrictMode": true,
     "typescript": {
         // !! WARN !!

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "license": "CC-BY-3.0",
       "dependencies": {
         "dateformat": "^5.0.3",
+        "express-rate-limit": "^8.2.1",
+        "ipfs-http-client": "^60.0.1",
+        "mime-types": "^3.0.2",
         "next": "^14.2.15",
         "react": "18.3.1",
         "react-dom": "18.3.1"
@@ -38,6 +41,449 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@chainsafe/is-ip": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chainsafe/is-ip/-/is-ip-2.1.0.tgz",
+      "integrity": "sha512-KIjt+6IfysQ4GCv66xihEitBjvhU/bixbbbFxdJ1sqCp4uJ0wuZiYBPhksZoy4lfaF0k9cwNzY5upEW/VWdw3w==",
+      "license": "MIT"
+    },
+    "node_modules/@chainsafe/netmask": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@chainsafe/netmask/-/netmask-2.0.0.tgz",
+      "integrity": "sha512-I3Z+6SWUoaljh3TBzCnCxjlUyN8tA+NAk5L6m9IxvCf1BENQTePzPMis97CoN/iMW1St3WN+AWCCRp+TTBRiDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1"
+      }
+    },
+    "node_modules/@dnsquery/dns-packet": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@dnsquery/dns-packet/-/dns-packet-6.1.1.tgz",
+      "integrity": "sha512-WXTuFvL3G+74SchFAtz3FgIYVOe196ycvGsMgvSH/8Goptb1qpIQtIuM4SOK9G9lhMWYpHxnXyy544ZhluFOew==",
+      "license": "MIT",
+      "dependencies": {
+        "@leichtgewicht/ip-codec": "^2.0.4",
+        "utf8-codec": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@ipld/dag-cbor": {
+      "version": "9.2.5",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.2.5.tgz",
+      "integrity": "sha512-84wSr4jv30biui7endhobYhXBQzQE4c/wdoWlFrKcfiwH+ofaPg8fwsM8okX9cOzkkrsAsNdDyH3ou+kiLquwQ==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "cborg": "^4.0.0",
+        "multiformats": "^13.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@ipld/dag-cbor/node_modules/multiformats": {
+      "version": "13.4.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
+      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
+      "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/@ipld/dag-json": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-10.2.6.tgz",
+      "integrity": "sha512-51yc5azhmkvc9mp2HV/vtJ8SlgFXADp55wAPuuAjQZ+yPurAYuTVddS3ke5vT4sjcd4DbE+DWjsMZGXjFB2cuA==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "cborg": "^4.4.0",
+        "multiformats": "^13.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@ipld/dag-json/node_modules/multiformats": {
+      "version": "13.4.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
+      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
+      "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/@ipld/dag-pb": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.1.5.tgz",
+      "integrity": "sha512-w4PZ2yPqvNmlAir7/2hsCRMqny1EY5jj26iZcSgxREJexmbAc2FI21jp26MqiNdfgAxvkCnf2N/TJI18GaDNwA==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "multiformats": "^13.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@ipld/dag-pb/node_modules/multiformats": {
+      "version": "13.4.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
+      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
+      "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/@leichtgewicht/ip-codec": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
+      "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
+      "license": "MIT"
+    },
+    "node_modules/@libp2p/interface": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.1.0.tgz",
+      "integrity": "sha512-RE7/XyvC47fQBe1cHxhMvepYKa5bFCUyFrrpj8PuM0E7JtzxU7F+Du5j4VXbg2yLDcToe0+j8mB7jvwE2AThYw==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@multiformats/dns": "^1.0.6",
+        "@multiformats/multiaddr": "^13.0.1",
+        "main-event": "^1.0.1",
+        "multiformats": "^13.4.0",
+        "progress-events": "^1.0.1",
+        "uint8arraylist": "^2.4.8"
+      }
+    },
+    "node_modules/@libp2p/interface-connection": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-4.0.0.tgz",
+      "integrity": "sha512-6xx/NmEc84HX7QmsjSC3hHredQYjHv4Dkf4G27adAPf+qN+vnPxmQ7gaTnk243a0++DOFTbZ2gKX/15G2B6SRg==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "it-stream-types": "^1.0.4",
+        "uint8arraylist": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-connection/node_modules/@multiformats/multiaddr": {
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.5.1.tgz",
+      "integrity": "sha512-+DDlr9LIRUS8KncI1TX/FfUn8F2dl6BIxJgshS/yFQCNB5IAF0OGzcwB39g5NLE22s4qqDePv0Qof6HdpJ/4aQ==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "@multiformats/dns": "^1.0.3",
+        "abort-error": "^1.0.1",
+        "multiformats": "^13.0.0",
+        "uint8-varint": "^2.0.1",
+        "uint8arrays": "^5.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-connection/node_modules/multiformats": {
+      "version": "13.4.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
+      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
+      "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/@libp2p/interface-connection/node_modules/uint8arrays": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
+      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-keychain": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-keychain/-/interface-keychain-2.0.5.tgz",
+      "integrity": "sha512-mb7QNgn9fIvC7CaJCi06GJ+a6DN6RVT9TmEi0NmedZGATeCArPeWWG7r7IfxNVXb9cVOOE1RzV1swK0ZxEJF9Q==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-peer-id": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.2.tgz",
+      "integrity": "sha512-9pZp9zhTDoVwzRmp0Wtxw0Yfa//Yc0GqBCJi3EznBDE6HGIAVvppR91wSh2knt/0eYg0AQj7Y35VSesUTzMCUg==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-peer-info": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-info/-/interface-peer-info-1.0.10.tgz",
+      "integrity": "sha512-HQlo8NwQjMyamCHJrnILEZz+YwEOXCB2sIIw3slIrhVUYeYlTaia1R6d9umaAeLHa255Zmdm4qGH8rJLRqhCcg==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@multiformats/multiaddr": "^12.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-peer-info/node_modules/@multiformats/multiaddr": {
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.5.1.tgz",
+      "integrity": "sha512-+DDlr9LIRUS8KncI1TX/FfUn8F2dl6BIxJgshS/yFQCNB5IAF0OGzcwB39g5NLE22s4qqDePv0Qof6HdpJ/4aQ==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "@multiformats/dns": "^1.0.3",
+        "abort-error": "^1.0.1",
+        "multiformats": "^13.0.0",
+        "uint8-varint": "^2.0.1",
+        "uint8arrays": "^5.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-peer-info/node_modules/multiformats": {
+      "version": "13.4.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
+      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
+      "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/@libp2p/interface-peer-info/node_modules/uint8arrays": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
+      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-pubsub": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-pubsub/-/interface-pubsub-3.0.7.tgz",
+      "integrity": "sha512-+c74EVUBTfw2sx1GE/z/IjsYO6dhur+ukF0knAppeZsRQ1Kgg6K5R3eECtT28fC6dBWLjFpAvW/7QGfiDAL4RA==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@libp2p/interface-connection": "^4.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "it-pushable": "^3.0.0",
+        "uint8arraylist": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface/node_modules/@multiformats/multiaddr": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-13.0.1.tgz",
+      "integrity": "sha512-XToN915cnfr6Lr9EdGWakGJbPT0ghpg/850HvdC+zFX8XvpLZElwa8synCiwa8TuvKNnny6m8j8NVBNCxhIO3g==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "multiformats": "^13.0.0",
+        "uint8-varint": "^2.0.1",
+        "uint8arrays": "^5.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface/node_modules/multiformats": {
+      "version": "13.4.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
+      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
+      "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/@libp2p/interface/node_modules/uint8arrays": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
+      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
+    "node_modules/@libp2p/interfaces": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.3.2.tgz",
+      "integrity": "sha512-p/M7plbrxLzuQchvNwww1Was7ZeGE2NaOFulMaZBYIihU8z3fhaV+a033OqnC/0NTX/yhfdNOG7znhYq3XoR/g==",
+      "license": "Apache-2.0 OR MIT",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/logger": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-2.1.1.tgz",
+      "integrity": "sha512-2UbzDPctg3cPupF6jrv6abQnAUTrbLybNOj0rmmrdGm1cN2HJ1o/hBu0sXuq4KF9P1h/eVRn1HIRbVIEKnEJrA==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.2",
+        "@multiformats/multiaddr": "^12.1.3",
+        "debug": "^4.3.4",
+        "interface-datastore": "^8.2.0",
+        "multiformats": "^11.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/logger/node_modules/@multiformats/multiaddr": {
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.5.1.tgz",
+      "integrity": "sha512-+DDlr9LIRUS8KncI1TX/FfUn8F2dl6BIxJgshS/yFQCNB5IAF0OGzcwB39g5NLE22s4qqDePv0Qof6HdpJ/4aQ==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "@multiformats/dns": "^1.0.3",
+        "abort-error": "^1.0.1",
+        "multiformats": "^13.0.0",
+        "uint8-varint": "^2.0.1",
+        "uint8arrays": "^5.0.0"
+      }
+    },
+    "node_modules/@libp2p/logger/node_modules/@multiformats/multiaddr/node_modules/multiformats": {
+      "version": "13.4.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
+      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
+      "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/@libp2p/logger/node_modules/uint8arrays": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
+      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
+    "node_modules/@libp2p/logger/node_modules/uint8arrays/node_modules/multiformats": {
+      "version": "13.4.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
+      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
+      "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/@libp2p/peer-id": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-2.0.4.tgz",
+      "integrity": "sha512-gcOsN8Fbhj6izIK+ejiWsqiqKeJ2yWPapi/m55VjOvDa52/ptQzZszxQP8jUk93u36de92ATFXDfZR/Bi6eeUQ==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.2.0",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@multiformats/dns": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@multiformats/dns/-/dns-1.0.13.tgz",
+      "integrity": "sha512-yr4bxtA3MbvJ+2461kYIYMsiiZj/FIqKI64hE4SdvWJUdWF9EtZLar38juf20Sf5tguXKFUruluswAO6JsjS2w==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@dnsquery/dns-packet": "^6.1.1",
+        "@libp2p/interface": "^3.1.0",
+        "hashlru": "^2.3.0",
+        "p-queue": "^9.0.0",
+        "progress-events": "^1.0.0",
+        "uint8arrays": "^5.0.2"
+      }
+    },
+    "node_modules/@multiformats/dns/node_modules/multiformats": {
+      "version": "13.4.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
+      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
+      "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/@multiformats/dns/node_modules/uint8arrays": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
+      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
+    "node_modules/@multiformats/multiaddr": {
+      "version": "11.6.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.6.1.tgz",
+      "integrity": "sha512-doST0+aB7/3dGK9+U5y3mtF3jq85KGbke1QiH0KE1F5mGQ9y56mFebTeu2D9FNOm+OT6UHb8Ss8vbSnpGjeLNw==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "err-code": "^3.0.1",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@multiformats/multiaddr-to-uri": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr-to-uri/-/multiaddr-to-uri-9.0.8.tgz",
+      "integrity": "sha512-4eiN5iEiQfy2A98BxekUfW410L/ivg0sgjYSgSqmklnrBhK+QyMz4yqgfkub8xDTXOc7O5jp4+LVyM3ZqMeWNw==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@multiformats/multiaddr": "^12.0.0"
+      }
+    },
+    "node_modules/@multiformats/multiaddr-to-uri/node_modules/@multiformats/multiaddr": {
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.5.1.tgz",
+      "integrity": "sha512-+DDlr9LIRUS8KncI1TX/FfUn8F2dl6BIxJgshS/yFQCNB5IAF0OGzcwB39g5NLE22s4qqDePv0Qof6HdpJ/4aQ==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "@multiformats/dns": "^1.0.3",
+        "abort-error": "^1.0.1",
+        "multiformats": "^13.0.0",
+        "uint8-varint": "^2.0.1",
+        "uint8arrays": "^5.0.0"
+      }
+    },
+    "node_modules/@multiformats/multiaddr-to-uri/node_modules/multiformats": {
+      "version": "13.4.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
+      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
+      "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/@multiformats/multiaddr-to-uri/node_modules/uint8arrays": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
+      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "multiformats": "^13.0.0"
       }
     },
     "node_modules/@next/env": {
@@ -227,6 +673,70 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
@@ -552,11 +1062,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/minimatch": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.16.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.1.tgz",
       "integrity": "sha512-zJDo7wEadFtSyNz5QITDfRcrhqDvQI1xQNQ0VoizPjM/dVAODqqIUWbJPkvsxmTI0MYRGRikcdjMPhOssnPejQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -748,6 +1263,32 @@
         "node": "^14.14.0 || >=16.0.0"
       }
     },
+    "node_modules/abort-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/abort-error/-/abort-error-1.0.1.tgz",
+      "integrity": "sha512-fxqCblJiIPdSXIUrxI0PL+eJG49QdP9SQ70qtB65MVAoMr2rASlOyAbJFOylfB467F/f+5BCLJJq58RYi7mGfg==",
+      "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/any-signal": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-3.0.1.tgz",
+      "integrity": "sha512-xgZgJtKEa9YmDqXodIgl7Fl1C8yNXr8w6gXjqK3LW4GcEiYT+6AQfJSE/8SPsEpLLmcvbv8YU+qet94UewHxqg==",
+      "license": "MIT"
+    },
     "node_modules/arch": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/arch/-/arch-3.0.0.tgz",
@@ -790,7 +1331,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/bare-events": {
@@ -805,7 +1345,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -857,6 +1396,40 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/blob-to-it": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/blob-to-it/-/blob-to-it-2.0.10.tgz",
+      "integrity": "sha512-I39vO57y+LBEIcAV7fif0sn96fYOYVqrPiOD+53MxQGv4DBgt1/HHZh0BHheWx2hVe24q5LTSXxqeV1Y3Nzkgg==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "browser-readablestream-to-it": "^2.0.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -879,6 +1452,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/browser-readablestream-to-it": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-2.0.10.tgz",
+      "integrity": "sha512-I/9hEcRtjct8CzD9sVo9Mm4ntn0D+7tOVrjbPl69XAoOfgJ8NBdOQU+WX+5SHhcELJDb14mWt7zuvyqha+MEAQ==",
+      "license": "Apache-2.0 OR MIT"
     },
     "node_modules/buffer": {
       "version": "5.7.1",
@@ -926,6 +1505,16 @@
         "node": ">=10.16.0"
       }
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/cacheable-lookup": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
@@ -955,6 +1544,37 @@
         "node": ">=14.16"
       }
     },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001651",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001651.tgz",
@@ -975,6 +1595,15 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/cborg": {
+      "version": "4.5.8",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.5.8.tgz",
+      "integrity": "sha512-6/viltD51JklRhq4L7jC3zgy6gryuG5xfZ3kzpE+PravtyeQLeQmCYLREhQH7pWENg5pY4Yu/XCd6a7dKScVlw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "cborg": "lib/bin.js"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -991,6 +1620,12 @@
         "node": ">= 12"
       }
     },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
+    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -1002,6 +1637,36 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.6.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -1026,6 +1691,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dag-jose": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/dag-jose/-/dag-jose-4.0.0.tgz",
+      "integrity": "sha512-tw595L3UYoOUT9dSJPbBEG/qpRpw24kRZxa5SLRnlnr+g5L7O8oEs1d3W5TiVA1oJZbthVsf0Vi3zFN66qcEBA==",
+      "license": "(Apache-2.0 OR MIT)",
+      "dependencies": {
+        "@ipld/dag-cbor": "^9.0.0",
+        "multiformats": "^11.0.0"
+      }
+    },
     "node_modules/dateformat": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-5.0.3.tgz",
@@ -1033,6 +1708,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.20"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/decompress-response": {
@@ -1087,6 +1779,139 @@
         "node": ">=10"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dns-over-http-resolver": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.3.tgz",
+      "integrity": "sha512-zjRYFhq+CsxPAouQWzOsxNMvEN+SHisjzhX8EMxd2Y0EG3thvn6wXQgMJLnTDImkhe4jhLbOQpXtL10nALBOSA==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "native-fetch": "^4.0.2",
+        "receptacle": "^1.3.2",
+        "undici": "^5.12.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/electron-fetch": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/electron-fetch/-/electron-fetch-1.9.1.tgz",
+      "integrity": "sha512-M9qw6oUILGVrcENMSRRefE1MbHPIz0h79EKIeJWK9v563aT9Qkh8aEHPO1H5vi970wPirNY+jO9OpFoLiMsMGA==",
+      "license": "MIT",
+      "dependencies": {
+        "encoding": "^0.1.13"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/err-code": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
+      "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA==",
+      "license": "MIT"
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -1100,6 +1925,22 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/execa": {
       "version": "5.1.1",
@@ -1123,6 +1964,82 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
+      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express/node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ext-list": {
@@ -1169,7 +2086,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -1290,6 +2206,28 @@
         "node": ">=8"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/find-versions": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-5.1.0.tgz",
@@ -1316,6 +2254,81 @@
         "node": ">= 14.17"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-iterator": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-1.0.2.tgz",
+      "integrity": "sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg==",
+      "license": "MIT"
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/get-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
@@ -1340,6 +2353,19 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/got": {
@@ -1390,12 +2416,65 @@
         "node": ">=6.0"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hashlru": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
+      "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A==",
+      "license": "MIT"
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/http-cache-semantics": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
       "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/http2-wrapper": {
       "version": "2.2.1",
@@ -1421,11 +2500,27 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1442,6 +2537,12 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
     "node_modules/inspect-with-kind": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/inspect-with-kind/-/inspect-with-kind-1.0.5.tgz",
@@ -1451,6 +2552,313 @@
       "dependencies": {
         "kind-of": "^6.0.2"
       }
+    },
+    "node_modules/interface-datastore": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.3.2.tgz",
+      "integrity": "sha512-R3NLts7pRbJKc3qFdQf+u40hK8XWc0w4Qkx3OFEstC80VoaDUABY/dXA2EJPhtNC+bsrf41Ehvqb6+pnIclyRA==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "interface-store": "^6.0.0",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/interface-datastore/node_modules/multiformats": {
+      "version": "13.4.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
+      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
+      "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/interface-datastore/node_modules/uint8arrays": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
+      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
+    "node_modules/interface-store": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-6.0.3.tgz",
+      "integrity": "sha512-+WvfEZnFUhRwFxgz+QCQi7UC6o9AM0EHM9bpIe2Nhqb100NHCsTvNAn4eJgvgV2/tmLo1MP9nGxQKEcZTAueLA==",
+      "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/ipfs-core-types": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/ipfs-core-types/-/ipfs-core-types-0.14.1.tgz",
+      "integrity": "sha512-4ujF8NlM9bYi2I6AIqPP9wfGGX0x/gRCkMoFdOQfxxrFg6HcAdfS+0/irK8mp4e7znOHWReOHeWqCGw+dAPwsw==",
+      "deprecated": "js-IPFS has been deprecated in favour of Helia - please see https://github.com/ipfs/js-ipfs/issues/4336 for details",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@ipld/dag-pb": "^4.0.0",
+        "@libp2p/interface-keychain": "^2.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.2",
+        "@libp2p/interface-pubsub": "^3.0.0",
+        "@multiformats/multiaddr": "^11.1.5",
+        "@types/node": "^18.0.0",
+        "interface-datastore": "^7.0.0",
+        "ipfs-unixfs": "^9.0.0",
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-core-types/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/ipfs-core-types/node_modules/interface-datastore": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-7.0.4.tgz",
+      "integrity": "sha512-Q8LZS/jfFFHz6XyZazLTAc078SSCoa27ZPBOfobWdpDiFO7FqPA2yskitUJIhaCgxNK8C+/lMBUTBNfVIDvLiw==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "interface-store": "^3.0.0",
+        "nanoid": "^4.0.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-core-types/node_modules/interface-store": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.4.tgz",
+      "integrity": "sha512-OjHUuGXbH4eXSBx1TF1tTySvjLldPLzRSYYXJwrEQI+XfH5JWYZofr0gVMV4F8XTwC+4V7jomDYkvGRmDSRKqQ==",
+      "license": "Apache-2.0 OR MIT",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-core-types/node_modules/nanoid": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "node_modules/ipfs-core-types/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
+    "node_modules/ipfs-core-utils": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.18.1.tgz",
+      "integrity": "sha512-P7jTpdfvlyBG3JR4o+Th3QJADlmXmwMxbkjszXry6VAjfSfLIIqXsdeYPoVRkV69GFEeQozuz2k/jR+U8cUH/Q==",
+      "deprecated": "js-IPFS has been deprecated in favour of Helia - please see https://github.com/ipfs/js-ipfs/issues/4336 for details",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@libp2p/logger": "^2.0.5",
+        "@multiformats/multiaddr": "^11.1.5",
+        "@multiformats/multiaddr-to-uri": "^9.0.1",
+        "any-signal": "^3.0.0",
+        "blob-to-it": "^2.0.0",
+        "browser-readablestream-to-it": "^2.0.0",
+        "err-code": "^3.0.1",
+        "ipfs-core-types": "^0.14.1",
+        "ipfs-unixfs": "^9.0.0",
+        "ipfs-utils": "^9.0.13",
+        "it-all": "^2.0.0",
+        "it-map": "^2.0.0",
+        "it-peekable": "^2.0.0",
+        "it-to-stream": "^1.0.0",
+        "merge-options": "^3.0.4",
+        "multiformats": "^11.0.0",
+        "nanoid": "^4.0.0",
+        "parse-duration": "^1.0.0",
+        "timeout-abort-controller": "^3.0.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-core-utils/node_modules/nanoid": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "node_modules/ipfs-http-client": {
+      "version": "60.0.1",
+      "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-60.0.1.tgz",
+      "integrity": "sha512-amwM5TNuf077J+/q27jPHfatC05vJuIbX6ZnlYLjc2QsjOCKsORNBqV3brNw7l+fPrijV1yrwEDLG3JEnKsfMw==",
+      "deprecated": "js-IPFS has been deprecated in favour of Helia - please see https://github.com/ipfs/js-ipfs/issues/4336 for details",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@ipld/dag-cbor": "^9.0.0",
+        "@ipld/dag-json": "^10.0.0",
+        "@ipld/dag-pb": "^4.0.0",
+        "@libp2p/logger": "^2.0.5",
+        "@libp2p/peer-id": "^2.0.0",
+        "@multiformats/multiaddr": "^11.1.5",
+        "any-signal": "^3.0.0",
+        "dag-jose": "^4.0.0",
+        "err-code": "^3.0.1",
+        "ipfs-core-types": "^0.14.1",
+        "ipfs-core-utils": "^0.18.1",
+        "ipfs-utils": "^9.0.13",
+        "it-first": "^2.0.0",
+        "it-last": "^2.0.0",
+        "merge-options": "^3.0.4",
+        "multiformats": "^11.0.0",
+        "parse-duration": "^1.0.0",
+        "stream-to-it": "^0.2.2",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-unixfs": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-9.0.1.tgz",
+      "integrity": "sha512-jh2CbXyxID+v3jLml9CqMwjdSS9ZRnsGfQGGPOfem0/hT/L48xUeTPvh7qLFWkZcIMhZtG+fnS1teei8x5uGBg==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "err-code": "^3.0.1",
+        "protobufjs": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-utils": {
+      "version": "9.0.14",
+      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-9.0.14.tgz",
+      "integrity": "sha512-zIaiEGX18QATxgaS0/EOQNoo33W0islREABAcxXE8n7y2MGAlB+hdsxXn4J0hGZge8IqVQhW8sWIb+oJz2yEvg==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "any-signal": "^3.0.0",
+        "browser-readablestream-to-it": "^1.0.0",
+        "buffer": "^6.0.1",
+        "electron-fetch": "^1.7.2",
+        "err-code": "^3.0.1",
+        "is-electron": "^2.2.0",
+        "iso-url": "^1.1.5",
+        "it-all": "^1.0.4",
+        "it-glob": "^1.0.1",
+        "it-to-stream": "^1.0.0",
+        "merge-options": "^3.0.4",
+        "nanoid": "^3.1.20",
+        "native-fetch": "^3.0.0",
+        "node-fetch": "^2.6.8",
+        "react-native-fetch-api": "^3.0.0",
+        "stream-to-it": "^0.2.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-utils/node_modules/browser-readablestream-to-it": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-1.0.3.tgz",
+      "integrity": "sha512-+12sHB+Br8HIh6VAMVEG5r3UXCyESIgDW7kzk3BjIXa43DVqVwL7GC5TW3jeh+72dtcH99pPVpw0X8i0jt+/kw==",
+      "license": "ISC"
+    },
+    "node_modules/ipfs-utils/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/ipfs-utils/node_modules/it-all": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.6.tgz",
+      "integrity": "sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A==",
+      "license": "ISC"
+    },
+    "node_modules/ipfs-utils/node_modules/native-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-3.0.0.tgz",
+      "integrity": "sha512-G3Z7vx0IFb/FQ4JxvtqGABsOTIqRWvgQz6e+erkB+JJD6LrszQtMozEHI4EkmgZQvnGHrpLVzUWk7t4sJCIkVw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "node-fetch": "*"
+      }
+    },
+    "node_modules/is-electron": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
+      "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==",
+      "license": "MIT"
     },
     "node_modules/is-extendable": {
       "version": "0.1.1",
@@ -1505,6 +2913,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -1524,6 +2939,163 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/iso-url": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-1.2.1.tgz",
+      "integrity": "sha512-9JPDgCN4B7QPkLtYAAOrEuAWvP9rWvR5offAr0/SeF046wIkglqH3VXgYYP6NcsKslH80UIVgmPqNe3j7tG2ng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/it-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-2.0.1.tgz",
+      "integrity": "sha512-9UuJcCRZsboz+HBQTNOau80Dw+ryGaHYFP/cPYzFBJBFcfDathMYnhHk4t52en9+fcyDGPTdLB+lFc1wzQIroA==",
+      "license": "Apache-2.0 OR MIT",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-first": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-first/-/it-first-2.0.1.tgz",
+      "integrity": "sha512-noC1oEQcWZZMUwq7VWxHNLML43dM+5bviZpfmkxkXlvBe60z7AFRqpZSga9uQBo792jKv9otnn1IjA4zwgNARw==",
+      "license": "Apache-2.0 OR MIT",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-glob": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-1.0.2.tgz",
+      "integrity": "sha512-Ch2Dzhw4URfB9L/0ZHyY+uqOnKvBNeS/SMcRiPmJfpHiM0TsUZn+GkpcZxAoF3dJVdPm/PuIk3A4wlV7SUo23Q==",
+      "license": "ISC",
+      "dependencies": {
+        "@types/minimatch": "^3.0.4",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "node_modules/it-glob/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/it-glob/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/it-last": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-last/-/it-last-2.0.1.tgz",
+      "integrity": "sha512-uVMedYW0wa2Cx0TAmcOCLbfuLLII7+vyURmhKa8Zovpd+aBTMsmINtsta2n364wJ5qsEDBH+akY1sUtAkaYBlg==",
+      "license": "Apache-2.0 OR MIT",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-map": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-map/-/it-map-2.0.1.tgz",
+      "integrity": "sha512-a2GcYDHiAh/eSU628xlvB56LA98luXZnniH2GlD0IdBzf15shEq9rBeb0Rg3o1SWtNILUAwqmQxEXcewGCdvmQ==",
+      "license": "Apache-2.0 OR MIT",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-peekable": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-2.0.1.tgz",
+      "integrity": "sha512-fJ/YTU9rHRhGJOM2hhQKKEfRM6uKB9r4yGGFLBHqp72ACC8Yi6+7/FhuBAMG8cpN6mLoj9auVX7ZJ3ul6qFpTA==",
+      "license": "Apache-2.0 OR MIT",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-pushable": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.2.3.tgz",
+      "integrity": "sha512-gzYnXYK8Y5t5b/BnJUr7glfQLO4U5vyb05gPx/TyTw+4Bv1zM9gFk4YsOrnulWefMewlphCjKkakFvj1y99Tcg==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "p-defer": "^4.0.0"
+      }
+    },
+    "node_modules/it-stream-types": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-1.0.5.tgz",
+      "integrity": "sha512-I88Ka1nHgfX62e5mi5LLL+oueqz7Ltg0bUdtsUKDe9SoUqbQPf2Mp5kxDTe9pNhHQGs4pvYPAINwuZ1HAt42TA==",
+      "license": "Apache-2.0 OR MIT",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-to-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/it-to-stream/-/it-to-stream-1.0.0.tgz",
+      "integrity": "sha512-pLULMZMAB/+vbdvbZtebC0nWBTbG581lk6w8P7DfIIIKUfa8FbY7Oi0FxZcFPbxvISs7A9E+cMpLDBc1XhpAOA==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "fast-fifo": "^1.0.0",
+        "get-iterator": "^1.0.2",
+        "p-defer": "^3.0.0",
+        "p-fifo": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      }
+    },
+    "node_modules/it-to-stream/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/it-to-stream/node_modules/p-defer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+      "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -1572,6 +3144,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -1596,6 +3174,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/main-event": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/main-event/-/main-event-1.0.1.tgz",
+      "integrity": "sha512-NWtdGrAca/69fm6DIVd8T9rtfDII4Q8NQbIbsKQq2VzS9eqOGYs8uaNQjcuaCq/d9H/o625aOTJX2Qoxzqw0Pw==",
+      "license": "Apache-2.0 OR MIT"
     },
     "node_modules/make-dir": {
       "version": "4.0.0",
@@ -1624,6 +3208,60 @@
       },
       "peerDependencies": {
         "react": ">= 0.14.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/merge-options/node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/merge-stream": {
@@ -1658,13 +3296,28 @@
       }
     },
     "node_modules/mime-db": {
-      "version": "1.53.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.53.0.tgz",
-      "integrity": "sha512-oHlN/w+3MQ3rba9rqFr6V/ypF10LSkdwUysQL7GkXoTgIWeV+tcXGA852TBxH+gsh8UWoyhR1hKcoMJTuWflpg==",
-      "dev": true,
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/mimic-fn": {
@@ -1706,6 +3359,22 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "license": "Apache-2.0 OR MIT",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.8",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
@@ -1722,6 +3391,25 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/native-fetch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-4.0.2.tgz",
+      "integrity": "sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "undici": "*"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/next": {
@@ -1798,6 +3486,26 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-gyp-build": {
       "version": "4.8.1",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.1.tgz",
@@ -1837,6 +3545,42 @@
         "node": ">=8"
       }
     },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/onetime": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
@@ -1863,6 +3607,81 @@
         "node": ">=12.20"
       }
     },
+    "node_modules/p-defer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.1.tgz",
+      "integrity": "sha512-Mr5KC5efvAK5VUptYEIopP1bakB85k2IWXaRC0rsh1uwn1L6M0LVml8OIQ4Gudg4oyZakf7FmeRLkMMtZW1i5A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-fifo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-fifo/-/p-fifo-1.0.0.tgz",
+      "integrity": "sha512-IjoCxXW48tqdtDFz6fqo5q1UfFVjjVZe8TC1QRflvNUJtNfCUhxOUw6MOVZhDPjqhSzc26xKdugsO17gmzd5+A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-fifo": "^1.0.0",
+        "p-defer": "^3.0.0"
+      }
+    },
+    "node_modules/p-fifo/node_modules/p-defer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+      "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.1.0.tgz",
+      "integrity": "sha512-O/ZPaXuQV29uSLbxWBGGZO1mCQXV2BLIwUr59JUU9SoH76mnYvtms7aafH/isNSNGwuEfP6W/4xD0/TJXxrizw==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "p-timeout": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-duration": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-1.1.2.tgz",
+      "integrity": "sha512-p8EIONG8L0u7f8GFgfVlL4n8rnChTt8O5FSxgxMz2tjc9FMP199wxVKVB6IbKx11uTbKHACSvaLVIKNnoeNR/A==",
+      "license": "MIT"
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -1871,6 +3690,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/peek-readable": {
@@ -1951,6 +3781,66 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/progress-events": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/progress-events/-/progress-events-1.0.1.tgz",
+      "integrity": "sha512-MOzLIwhpt64KIVN64h1MwdKWiyKFNc/S6BoYKPIVUHFg0/eIEyBulhWCgn678v/4c0ri3FdGuzXymNCv02MUIw==",
+      "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -1985,6 +3875,32 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -2008,6 +3924,47 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-native-fetch-api": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-fetch-api/-/react-native-fetch-api-3.0.0.tgz",
+      "integrity": "sha512-g2rtqPjdroaboDKTsJCTlcmtw54E25OjyaunUP0anOZn4Fuo2IKs8BVfe02zVggA/UysbmfSnRJIqtNkAgggNA==",
+      "license": "MIT",
+      "dependencies": {
+        "p-defer": "^3.0.0"
+      }
+    },
+    "node_modules/react-native-fetch-api/node_modules/p-defer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+      "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/receptacle": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/receptacle/-/receptacle-1.3.2.tgz",
+      "integrity": "sha512-HrsFvqZZheusncQRiEE7GatOAETrARKV/lnfYicIm8lbvp/JQOdADOfhjBd2DajvoszEyxSM6RlAAIZgEoeu/A==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
       }
     },
     "node_modules/regenerator-runtime": {
@@ -2040,6 +3997,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/retimer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/retimer/-/retimer-3.0.0.tgz",
+      "integrity": "sha512-WKE0j11Pa0ZJI5YIk0nflGI7SQsfl2ljihVy7ogh7DeQSeYAUi0ubZ/yEueGtDfUPk6GH5LRw1hBdLq4IwUBWA==",
+      "license": "MIT"
+    },
     "node_modules/reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -2049,6 +4012,23 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/run-parallel": {
@@ -2079,7 +4059,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2094,6 +4073,12 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
     "node_modules/scheduler": {
@@ -2185,6 +4170,60 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC",
+      "peer": true
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -2206,6 +4245,82 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {
@@ -2277,6 +4392,25 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/stream-to-it": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-0.2.4.tgz",
+      "integrity": "sha512-4vEbkSs83OahpmBybNJXlJd7d6/RxzkkSdT3I0mnGt79Xd2Kk+e1JqbvAvsQfCeKj3aKb0QIWkyK3/n0j506vQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-iterator": "^1.0.2"
+      }
+    },
     "node_modules/streamsearch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
@@ -2297,6 +4431,15 @@
       },
       "optionalDependencies": {
         "bare-events": "^2.2.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/strip-bom-string": {
@@ -2400,6 +4543,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/timeout-abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/timeout-abort-controller/-/timeout-abort-controller-3.0.0.tgz",
+      "integrity": "sha512-O3e+2B8BKrQxU2YRyEjC/2yFdb33slI22WRdUaDx6rvysfi9anloNZyR2q0l6LnePo5qH7gSM7uZtvvwZbc2yA==",
+      "license": "MIT",
+      "dependencies": {
+        "retimer": "^3.0.0"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -2411,6 +4563,16 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/token-types": {
@@ -2431,11 +4593,32 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/tslib": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
       "license": "0BSD"
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/typescript": {
       "version": "5.5.4",
@@ -2451,6 +4634,31 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uint8-varint": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.4.tgz",
+      "integrity": "sha512-FwpTa7ZGA/f/EssWAb5/YV6pHgVF1fViKdW8cWaEarjB8t7NyofSWBdOTyFPaGuUG4gx3v1O3PQ8etsiOs3lcw==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^5.0.0"
+      }
+    },
+    "node_modules/uint8-varint/node_modules/multiformats": {
+      "version": "13.4.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
+      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
+      "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/uint8-varint/node_modules/uint8arrays": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
+      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
     "node_modules/uint8array-extras": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.4.0.tgz",
@@ -2464,6 +4672,49 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/uint8arraylist": {
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.8.tgz",
+      "integrity": "sha512-vc1PlGOzglLF0eae1M8mLRTBivsvrGsdmJ5RbK3e+QRvRLOZfZhQROTwH/OfyF3+ZVUg9/8hE8bmKP2CvP9quQ==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "uint8arrays": "^5.0.1"
+      }
+    },
+    "node_modules/uint8arraylist/node_modules/multiformats": {
+      "version": "13.4.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
+      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
+      "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/uint8arraylist/node_modules/uint8arrays": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
+      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
+    "node_modules/uint8arrays": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.10.tgz",
+      "integrity": "sha512-AnJNUGGDJAgFw/eWu/Xb9zrVKEGlwJJCaeInlf3BkecE/zcTobk5YXYIPNQJO1q5Hh1QZrQQHf0JvcHqz2hqoA==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/uint8arrays/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "license": "Apache-2.0 OR MIT",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/unbzip2-stream": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
@@ -2475,12 +4726,77 @@
         "through": "^2.3.8"
       }
     },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utf8-codec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/utf8-codec/-/utf8-codec-1.0.0.tgz",
+      "integrity": "sha512-S/QSLezp3qvG4ld5PUfXiH7mCFxLKjSVZRFkB3DOjgwHuJPFDkInAXc/anf7BAbHt/D38ozDzL+QMZ6/7gsI6w==",
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/varint": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+      "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==",
+      "license": "MIT"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -2497,6 +4813,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/yauzl": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -4,11 +4,14 @@
   "version": "1.0.0",
   "author": "John Hall",
   "license": "CC-BY-3.0",
-  "main": "index.js",
+  "main": "server.js",
   "private": true,
   "repository": "Real-Currents/www",
   "dependencies": {
     "dateformat": "^5.0.3",
+    "express-rate-limit": "^8.2.1",
+    "ipfs-http-client": "^60.0.1",
+    "mime-types": "^3.0.2",
     "next": "^14.2.15",
     "react": "18.3.1",
     "react-dom": "18.3.1"
@@ -29,7 +32,7 @@
     "build": "npm run render:markdown && npm run build:next",
     "build:next": "next build",
     "clean": "rm -rf _freeze/* _site/*",
-    "dev": "npm run render:markdown && npm run dev:next",
+    "dev": "npm run render:markdown && NODE_ENV=development node server.js",
     "dev:next": "next dev",
     "lint": "next lint",
     "next": "next",
@@ -41,7 +44,8 @@
     "render:js-demos": "bash -c \"cd content/js-demos && quarto render --output-dir . && quarto render index.qmd --to gfm --output README.md --output-dir . && quarto render index.qmd --to html --output index.html --output-dir .  && cd ../../ && ls -l ./ && cp -LR site_libs public/ && rm -rf site_libs && rm search.json\"",
     "render:posts": "cd content/posts && quarto render --output-dir .",
     "render:readme": "quarto render content/README.qmd --to gfm --output README.md",
-    "start": "python -m http.server -d out 3000",
+    "start": "NODE_ENV=production node server.js",
+    "start:static": "python -m http.server -d out 3000",
     "start:adb-port-forwarding": "adb reverse tcp:3000 tcp:3000"
   },
   "type": "module"

--- a/server.js
+++ b/server.js
@@ -1,0 +1,652 @@
+import { createServer } from "node:http";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { parse } from "node:url";
+
+import next from "next";
+import { create as createIpfsClient } from "ipfs-http-client";
+import mime from "mime-types";
+
+const dev = process.env.NODE_ENV !== "production";
+const port = Number(process.env.PORT || 3000);
+const staticDir = path.join(process.cwd(), "out");
+
+const MAX_CAR_UPLOAD_BYTES = 1024 * 1024 * 1024; // 1 GB
+const MAX_JSON_BYTES = 1024 * 1024; // 1 MB
+
+const IPNS_CACHE_TTL = 5 * 60 * 1000;
+const KEY_ALIAS_CACHE_TTL = 60 * 1000;
+
+const ipnsCache = new Map();
+let keyAliasCache = { timestamp: 0, entries: new Map() };
+let ipfsClient;
+let nextHandler = null;
+
+class MissingIpfsConfigError extends Error {}
+
+function isAsyncIterable(value) {
+  return value != null && typeof value[Symbol.asyncIterator] === "function";
+}
+
+async function firstAsyncValue(value) {
+  if (isAsyncIterable(value)) {
+    for await (const item of value) {
+      return item;
+    }
+    return undefined;
+  }
+
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+
+  return value;
+}
+
+function writeJson(res, statusCode, payload) {
+  res.statusCode = statusCode;
+  res.setHeader("Content-Type", "application/json; charset=utf-8");
+  res.end(JSON.stringify(payload));
+}
+
+function writeText(res, statusCode, message) {
+  res.statusCode = statusCode;
+  res.setHeader("Content-Type", "text/plain; charset=utf-8");
+  res.end(message);
+}
+
+function sanitizeRelativePath(relativePath) {
+  const normalized = path.posix.normalize(relativePath || "");
+
+  if (!normalized || normalized === "." || normalized === "/") {
+    return "index.html";
+  }
+
+  if (normalized === ".." || normalized.startsWith("../") || normalized.includes("/../")) {
+    return null;
+  }
+
+  return normalized.replace(/^\/+/, "");
+}
+
+function staticCandidatesForPath(pathname) {
+  const cleanPath = pathname || "/";
+  const stripped = cleanPath.replace(/^\/+/, "");
+
+  if (cleanPath === "/") {
+    return ["index.html"];
+  }
+
+  const candidates = new Set();
+  candidates.add(stripped);
+
+  if (cleanPath.endsWith("/")) {
+    candidates.add(path.posix.join(stripped, "index.html"));
+  }
+
+  if (!path.posix.extname(stripped)) {
+    candidates.add(`${stripped}.html`);
+    candidates.add(path.posix.join(stripped, "index.html"));
+  }
+
+  return Array.from(candidates)
+    .map((candidate) => sanitizeRelativePath(candidate))
+    .filter(Boolean);
+}
+
+function gatewayCandidates(parts, offset, pathname) {
+  const rawSubPath = parts.slice(offset).join("/");
+  const normalizedRaw = path.posix.normalize(rawSubPath || "");
+
+  if (
+    normalizedRaw === ".." ||
+    normalizedRaw.startsWith("../") ||
+    normalizedRaw.includes("/../")
+  ) {
+    throw new Error("Invalid gateway path");
+  }
+
+  const basePath =
+    !normalizedRaw || normalizedRaw === "." || normalizedRaw === "/"
+      ? ""
+      : normalizedRaw.replace(/^\/+/, "");
+
+  const candidates = new Set([basePath || "index.html"]);
+  const requestedDirectory = pathname.endsWith("/") || rawSubPath.length === 0;
+  const hasExtension = Boolean(path.posix.extname(basePath));
+
+  if (requestedDirectory) {
+    candidates.add(path.posix.join(basePath, "index.html"));
+  } else if (!hasExtension) {
+    candidates.add(path.posix.join(basePath, "index.html"));
+    candidates.add(`${basePath}.html`);
+  }
+
+  return Array.from(candidates)
+    .map((candidate) => sanitizeRelativePath(candidate))
+    .filter(Boolean);
+}
+
+function staticPathFromRelative(relativePath) {
+  const absolutePath = path.resolve(staticDir, relativePath);
+  const relative = path.relative(staticDir, absolutePath);
+
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    return null;
+  }
+
+  return absolutePath;
+}
+
+function cacheControlForFile(filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+
+  if (ext === ".html") {
+    return "public, max-age=0, must-revalidate";
+  }
+
+  if (
+    [
+      ".css",
+      ".gif",
+      ".ico",
+      ".jpeg",
+      ".jpg",
+      ".js",
+      ".mjs",
+      ".png",
+      ".svg",
+      ".webp",
+      ".woff",
+      ".woff2",
+    ].includes(ext)
+  ) {
+    return "public, max-age=31536000, immutable";
+  }
+
+  return "public, max-age=300";
+}
+
+async function tryReadStaticFile(relativePath) {
+  const absolutePath = staticPathFromRelative(relativePath);
+  if (!absolutePath) {
+    return null;
+  }
+
+  try {
+    const stat = await fs.stat(absolutePath);
+    if (!stat.isFile()) {
+      return null;
+    }
+
+    const content = await fs.readFile(absolutePath);
+    return { absolutePath, content };
+  } catch {
+    return null;
+  }
+}
+
+async function serveStaticExport(pathname, res) {
+  const decodedPathname = decodeURIComponent(pathname || "/");
+  const candidates = staticCandidatesForPath(decodedPathname);
+
+  for (const candidate of candidates) {
+    const file = await tryReadStaticFile(candidate);
+    if (!file) {
+      continue;
+    }
+
+    const contentType = mime.lookup(file.absolutePath) || "application/octet-stream";
+    res.statusCode = 200;
+    res.setHeader("Content-Type", contentType);
+    res.setHeader("Cache-Control", cacheControlForFile(file.absolutePath));
+    res.end(file.content);
+    return;
+  }
+
+  const notFound = await tryReadStaticFile("404.html");
+  if (notFound) {
+    res.statusCode = 404;
+    res.setHeader("Content-Type", "text/html; charset=utf-8");
+    res.setHeader("Cache-Control", "public, max-age=0, must-revalidate");
+    res.end(notFound.content);
+    return;
+  }
+
+  writeText(res, 404, "Not Found");
+}
+
+function resolveIpfsApiUrl() {
+  const host = process.env.IPFS_NODE_HOST;
+  if (!host) {
+    throw new MissingIpfsConfigError(
+      "Missing IPFS configuration. Set IPFS_NODE_HOST, IPFS_USER, and IPFS_PASS.",
+    );
+  }
+
+  if (host.startsWith("http://") || host.startsWith("https://")) {
+    const base = host.endsWith("/") ? host.slice(0, -1) : host;
+    return `${base}/api/v0`;
+  }
+
+  const protocol = process.env.IPFS_NODE_PROTOCOL || "https";
+  const gatewayPort = process.env.IPFS_NODE_PORT || "443";
+  return `${protocol}://${host}:${gatewayPort}/api/v0`;
+}
+
+function getIpfsClient() {
+  if (ipfsClient) {
+    return ipfsClient;
+  }
+
+  const user = process.env.IPFS_USER;
+  const pass = process.env.IPFS_PASS;
+
+  if (!user || !pass) {
+    throw new MissingIpfsConfigError(
+      "Missing IPFS credentials. Set IPFS_NODE_HOST, IPFS_USER, and IPFS_PASS.",
+    );
+  }
+
+  ipfsClient = createIpfsClient({
+    url: resolveIpfsApiUrl(),
+    headers: {
+      authorization: `Basic ${Buffer.from(`${user}:${pass}`).toString("base64")}`,
+    },
+  });
+
+  return ipfsClient;
+}
+
+function normalizeCid(value) {
+  if (typeof value !== "string") {
+    return "";
+  }
+
+  return value.replace(/^\/ipfs\//, "").trim();
+}
+
+async function readRequestBody(req, maxBytes) {
+  const chunks = [];
+  let byteLength = 0;
+
+  for await (const chunk of req) {
+    const chunkBuffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    byteLength += chunkBuffer.length;
+
+    if (byteLength > maxBytes) {
+      throw new Error(`Request body exceeds ${maxBytes} bytes`);
+    }
+
+    chunks.push(chunkBuffer);
+  }
+
+  return Buffer.concat(chunks);
+}
+
+async function readJsonBody(req) {
+  const body = await readRequestBody(req, MAX_JSON_BYTES);
+
+  if (!body.length) {
+    return {};
+  }
+
+  return JSON.parse(body.toString("utf8"));
+}
+
+function hasValidDeploySecret(req) {
+  const configuredSecret = process.env.DEPLOY_SECRET;
+  const suppliedSecret = req.headers["x-api-key"];
+
+  if (!configuredSecret) {
+    return false;
+  }
+
+  if (typeof suppliedSecret !== "string") {
+    return false;
+  }
+
+  return suppliedSecret === configuredSecret;
+}
+
+async function fetchFromIpfsByCid(cid, pathCandidates) {
+  const ipfs = getIpfsClient();
+  let lastError = new Error("Content not found");
+
+  for (const filePath of pathCandidates) {
+    try {
+      const chunks = [];
+
+      for await (const chunk of ipfs.cat(`${cid}/${filePath}`)) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      }
+
+      return {
+        content: Buffer.concat(chunks),
+        filePath,
+      };
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError;
+}
+
+function setGatewayHeaders(res, filePath, cacheControl) {
+  res.setHeader("Content-Type", mime.lookup(filePath) || "application/octet-stream");
+  res.setHeader("Cache-Control", cacheControl);
+  res.setHeader("Access-Control-Allow-Origin", "*");
+}
+
+async function handleIPFSRequest(res, pathname) {
+  const segments = pathname.split("/").filter(Boolean);
+  const cid = segments[1];
+
+  if (!cid) {
+    return writeText(res, 400, "Missing CID in /ipfs/<cid>/...");
+  }
+
+  try {
+    const pathCandidates = gatewayCandidates(segments, 2, pathname);
+    const { content, filePath } = await fetchFromIpfsByCid(cid, pathCandidates);
+
+    res.statusCode = 200;
+    setGatewayHeaders(res, filePath, "public, max-age=31536000, immutable");
+    res.end(content);
+  } catch (error) {
+    if (error instanceof MissingIpfsConfigError) {
+      return writeText(res, 503, error.message);
+    }
+
+    console.error("IPFS fetch error:", error);
+    writeText(res, 404, "IPFS content not found");
+  }
+}
+
+function getCachedIpnsResolution(name) {
+  const cached = ipnsCache.get(name);
+  if (!cached) {
+    return null;
+  }
+
+  if (Date.now() - cached.timestamp > IPNS_CACHE_TTL) {
+    ipnsCache.delete(name);
+    return null;
+  }
+
+  return cached.cid;
+}
+
+function looksLikeIpnsPeerId(name) {
+  return /^k[0-9a-z]+$/i.test(name) || /^Qm[1-9A-HJ-NP-Za-km-z]{44}$/.test(name);
+}
+
+async function getIpnsKeyAliases(ipfs) {
+  if (Date.now() - keyAliasCache.timestamp < KEY_ALIAS_CACHE_TTL && keyAliasCache.entries.size > 0) {
+    return keyAliasCache.entries;
+  }
+
+  const keys = await ipfs.key.list();
+  const entries = new Map();
+
+  for (const key of keys || []) {
+    if (key?.name && key?.id) {
+      entries.set(key.name, key.id);
+    }
+  }
+
+  keyAliasCache = {
+    timestamp: Date.now(),
+    entries,
+  };
+
+  return entries;
+}
+
+async function resolveIpnsNameToCid(ipnsName) {
+  const cached = getCachedIpnsResolution(ipnsName);
+  if (cached) {
+    return cached;
+  }
+
+  const ipfs = getIpfsClient();
+  let resolveName = ipnsName;
+
+  if (!looksLikeIpnsPeerId(ipnsName)) {
+    try {
+      const aliases = await getIpnsKeyAliases(ipfs);
+      const peerId = aliases.get(ipnsName);
+      if (peerId) {
+        resolveName = peerId;
+
+        const aliasCached = getCachedIpnsResolution(peerId);
+        if (aliasCached) {
+          ipnsCache.set(ipnsName, { cid: aliasCached, timestamp: Date.now() });
+          return aliasCached;
+        }
+      }
+    } catch (error) {
+      // Alias lookup is best effort; resolving by supplied name is still attempted.
+      console.warn("IPNS key alias lookup failed:", error);
+    }
+  }
+
+  const resolvedPath = await firstAsyncValue(ipfs.name.resolve(`/ipns/${resolveName}`));
+  if (typeof resolvedPath !== "string" || !resolvedPath.startsWith("/ipfs/")) {
+    throw new Error(`Unable to resolve IPNS name: ${ipnsName}`);
+  }
+
+  const cid = resolvedPath.replace("/ipfs/", "");
+  const timestamp = Date.now();
+  ipnsCache.set(ipnsName, { cid, timestamp });
+  ipnsCache.set(resolveName, { cid, timestamp });
+
+  return cid;
+}
+
+async function handleIPNSRequest(res, pathname) {
+  const segments = pathname.split("/").filter(Boolean);
+  const ipnsName = segments[1];
+
+  if (!ipnsName) {
+    return writeText(res, 400, "Missing IPNS name in /ipns/<name>/...");
+  }
+
+  try {
+    const cid = await resolveIpnsNameToCid(ipnsName);
+    const pathCandidates = gatewayCandidates(segments, 2, pathname);
+    const { content, filePath } = await fetchFromIpfsByCid(cid, pathCandidates);
+
+    res.statusCode = 200;
+    setGatewayHeaders(res, filePath, "public, max-age=300");
+    res.setHeader("X-IPFS-Path", `/ipfs/${cid}/${filePath}`);
+    res.end(content);
+  } catch (error) {
+    if (error instanceof MissingIpfsConfigError) {
+      return writeText(res, 503, error.message);
+    }
+
+    console.error("IPNS resolution error:", error);
+    writeText(res, 404, "IPNS name not found or resolution failed");
+  }
+}
+
+async function handleDeployRequest(req, res) {
+  if (!hasValidDeploySecret(req)) {
+    return writeText(res, 401, "Unauthorized");
+  }
+
+  try {
+    const carData = await readRequestBody(req, MAX_CAR_UPLOAD_BYTES);
+    if (!carData.length) {
+      return writeText(res, 400, "Missing CAR payload");
+    }
+
+    const ipfs = getIpfsClient();
+    const importResult = ipfs.dag.import([carData], { pinRoots: true });
+
+    let rootCid = "";
+    for await (const item of importResult) {
+      const cid = item?.root?.cid || (item?.root && item?.cid ? item.cid : null);
+      if (cid) {
+        rootCid = cid.toString();
+        break;
+      }
+    }
+
+    if (!rootCid) {
+      throw new Error("No root CID returned from CAR import");
+    }
+
+    console.log(`Deployed to IPFS: ${rootCid}`);
+    writeJson(res, 200, { cid: rootCid });
+  } catch (error) {
+    if (error instanceof MissingIpfsConfigError) {
+      return writeText(res, 503, error.message);
+    }
+
+    console.error("Deploy error:", error);
+    writeJson(res, 500, { error: error.message || "Deployment failed" });
+  }
+}
+
+async function extractPublishedName(publishResult, fallbackName) {
+  const resolved = await firstAsyncValue(publishResult);
+
+  if (!resolved) {
+    return fallbackName;
+  }
+
+  if (typeof resolved === "string") {
+    return resolved;
+  }
+
+  if (typeof resolved?.name === "string") {
+    return resolved.name;
+  }
+
+  return fallbackName;
+}
+
+async function handleIPNSPublish(req, res) {
+  if (!hasValidDeploySecret(req)) {
+    return writeText(res, 401, "Unauthorized");
+  }
+
+  try {
+    const body = await readJsonBody(req);
+    const key = typeof body.key === "string" ? body.key.trim() : "";
+    const cid = normalizeCid(body.cid);
+
+    if (!key || !cid) {
+      return writeText(res, 400, "Missing key or cid");
+    }
+
+    const ipfs = getIpfsClient();
+    console.log(`Publishing IPNS: ${key} -> ${cid}`);
+    const publishResult = await ipfs.name.publish(`/ipfs/${cid}`, { key });
+    const ipnsName = await extractPublishedName(publishResult, key);
+
+    // Clear stale entries so the next request resolves fresh values.
+    ipnsCache.delete(key);
+    ipnsCache.delete(ipnsName);
+    keyAliasCache.timestamp = 0;
+
+    console.log(`IPNS published: ${ipnsName}`);
+    writeJson(res, 200, { ipns: ipnsName, cid });
+  } catch (error) {
+    if (error instanceof MissingIpfsConfigError) {
+      return writeText(res, 503, error.message);
+    }
+
+    console.error("IPNS publish error:", error);
+    writeJson(res, 500, { error: error.message || "IPNS publish failed" });
+  }
+}
+
+async function prepareNextHandler() {
+  if (dev) {
+    const app = next({ dev });
+    await app.prepare();
+    return app.getRequestHandler();
+  }
+
+  const forceStaticMode = process.env.NEXT_SERVER_MODE === "static";
+  const forceNextMode = process.env.NEXT_SERVER_MODE === "next";
+
+  if (forceStaticMode) {
+    return null;
+  }
+
+  if (!forceNextMode) {
+    try {
+      await fs.access(path.join(staticDir, "index.html"));
+      // Prefer static exports in production when they exist.
+      return null;
+    } catch {
+      // Fall through and start Next's request handler.
+    }
+  }
+
+  const app = next({ dev });
+  await app.prepare();
+  return app.getRequestHandler();
+}
+
+async function bootstrap() {
+  try {
+    nextHandler = await prepareNextHandler();
+  } catch (error) {
+    if (dev) {
+      throw error;
+    }
+
+    console.warn("Next handler unavailable; falling back to static export serving:", error);
+    nextHandler = null;
+  }
+
+  createServer(async (req, res) => {
+    try {
+      const parsedUrl = parse(req.url || "/", true);
+      const pathname = parsedUrl.pathname || "/";
+
+      if (pathname.startsWith("/ipfs/")) {
+        return await handleIPFSRequest(res, pathname);
+      }
+
+      if (pathname.startsWith("/ipns/")) {
+        return await handleIPNSRequest(res, pathname);
+      }
+
+      if (pathname === "/api/deploy" && req.method === "POST") {
+        return await handleDeployRequest(req, res);
+      }
+
+      if (pathname === "/api/ipns/publish" && req.method === "POST") {
+        return await handleIPNSPublish(req, res);
+      }
+
+      if (nextHandler) {
+        return nextHandler(req, res, parsedUrl);
+      }
+
+      return await serveStaticExport(pathname, res);
+    } catch (error) {
+      if (error instanceof MissingIpfsConfigError) {
+        return writeText(res, 503, error.message);
+      }
+
+      console.error("Server error:", error);
+      writeText(res, 500, "Internal Server Error");
+    }
+  }).listen(port, (error) => {
+    if (error) {
+      throw error;
+    }
+
+    console.log(`> Ready on http://localhost:${port}`);
+  });
+}
+
+bootstrap();

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -580,3 +580,17 @@ div#title h1 {
   right:0;
   font-size:10pt;
 }
+
+* #background_container .ipfs-links {
+  position: fixed;
+  left: 6px;
+  bottom: 14px;
+  margin: 0;
+  max-width: 360px;
+  font-size: 10pt;
+  line-height: 125%;
+}
+
+* #background_container .ipfs-links * {
+  font-size: 10pt;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import type { Metadata } from "next";
 import Link from "next/link";
-import { Comfortaa, Inter, Bitter, Montserrat, Roboto } from "next/font/google";
+import { Comfortaa } from "next/font/google";
 import { getIntroContent } from "@/utils";
 
 import "./fonts.css";
@@ -20,6 +20,10 @@ export const metadata: HeaderLayoutProps = {
     ...getIntroContent().data,
   title: "Real~Currents",
   description: "Experiments in Information Experience Design (IxD)",
+  metadataBase: new URL("https://www.real-currents.com"),
+  alternates: {
+      canonical: "/xr/baseline-0",
+  },
 };
 
 // TODO: Use metadata props to build header
@@ -53,12 +57,24 @@ function HeaderLayout ({ title, description, subtitles }: HeaderLayoutProps) {
 }
 
 function FooterLayout () {
+  const snapshotCid = process.env.NEXT_PUBLIC_IPFS_SNAPSHOT_CID?.trim();
+
   return (
       <footer>
           <p id="copyright"></p>
           <p id="built_with">
-              ...built with <a href="https://nextjs.org/docs" target="_blank">Next.js</a>&nbsp;
-              &&nbsp;<a href="https://quarto.org/docs/get-started/" target="_blank">Quarto</a>
+              ...built with <a href="https://nextjs.org/docs" target="_blank" rel="noopener noreferrer">Next.js</a>&nbsp;
+              &&nbsp;<a href="https://quarto.org/docs/get-started/" target="_blank" rel="noopener noreferrer">Quarto</a>
+          </p>
+          <p className={"ipfs-links"}>
+              <strong>Permanent Web Links:</strong><br />
+              <a href="/ipns/xr-baseline-0">Latest Version (IPNS)</a>
+              {snapshotCid ? (
+                  <>
+                      {" | "}
+                      <a href={`/ipfs/${snapshotCid}`}>Immutable Snapshot (IPFS)</a>
+                  </>
+              ) : null}
           </p>
       </footer>
   );
@@ -69,9 +85,6 @@ export default function RootLayout ({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-
-    console.log(metadata);
-
     return (
         <html lang="en">
         <body className={comfortaa.className}>

--- a/src/app/xr/baseline-0/page.tsx
+++ b/src/app/xr/baseline-0/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+import HomePage from "@/app/page";
+
+export const metadata: Metadata = {
+  alternates: {
+    canonical: "/xr/baseline-0",
+  },
+};
+
+export default function Baseline0Page() {
+  return <HomePage />;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Integrates IPFS/IPNS capabilities into the Real-Currents site, enabling immutable content snapshots and stable, updateable pointers while maintaining HTTP compatibility.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR implements a 3-tier IPFS/IPNS integration: a custom Next.js gateway (`server.js`) to serve IPFS/IPNS content and handle authenticated deployment APIs, updated `package.json` scripts and dependencies, `next.config.mjs` adjustments for static export, new routing for `/xr/baseline-0` with canonical tags and IPFS/IPNS footer links, and a GitHub Actions workflow (`deploy.yml`) to automate site build, CAR packaging, and IPFS/IPNS publishing. This allows for verifiable, decentralized content alongside the traditional web experience.

---
<p><a href="https://cursor.com/agents/bc-e29fd368-99b0-4afa-aa76-7a26a8d94fbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e29fd368-99b0-4afa-aa76-7a26a8d94fbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->