### PR TITLE
refactor: migrate from ipfs-http-client to kubo-rpc-client

### DIFF
--- a/docs/IPFS-INTEGRATION.md
+++ b/docs/IPFS-INTEGRATION.md
@@ -14,7 +14,7 @@ This document summarizes the IPFS/IPNS integration implemented per the Real-Curr
   - `GET /api/ipfs/current` – Returns current CID for IPNS key (for footer links)
   - Falls through to Next.js for all other routes
 
-- **Dependencies added**: `ipfs-http-client`, `mime-types`
+- **Dependencies added**: `kubo-rpc-client` (Kubo HTTP RPC API client), `mime-types`
 
 - **Scripts updated**:
   - `dev` – Uses custom server (with Quarto render)

--- a/docs/SOVEREIGN-WORKER-SETUP.md
+++ b/docs/SOVEREIGN-WORKER-SETUP.md
@@ -42,12 +42,48 @@ ipfs version
 ## 2. Initialize Kubo
 
 ```bash
-# Initialize the repo (creates ~/.ipfs/)
+# Initialize the repo (creates ~/.ipfs/ by default)
 ipfs init
 
 # Optional: use lowpower profile on small VPS
 # ipfs init --profile=lowpower
 ```
+
+---
+
+## 2b. Configure Storage Directory (Optional)
+
+By default, Kubo stores all data under `~/.ipfs/` (or `$IPFS_PATH`). To use a different location (e.g. a larger mounted disk):
+
+**Option A: Custom path via `IPFS_PATH`**
+
+```bash
+# Choose a path (e.g. dedicated volume or larger partition)
+export IPFS_PATH=/var/lib/ipfs   # or /mnt/data/ipfs, etc.
+
+# Initialize in that location (must be empty)
+sudo mkdir -p $IPFS_PATH
+sudo chown $USER:$USER $IPFS_PATH
+ipfs init
+
+# Persist for systemd: set Environment=IPFS_PATH=/var/lib/ipfs in the service file (step 6)
+```
+
+**Option B: Move existing repo**
+
+```bash
+# Stop the daemon if running, then move
+ipfs shutdown 2>/dev/null || true
+mv ~/.ipfs /var/lib/ipfs
+
+# Use the new path (set in systemd or shell)
+export IPFS_PATH=/var/lib/ipfs
+ipfs daemon
+```
+
+**Option C: Datastore paths (advanced)**
+
+For fine-grained control (e.g. blocks on one disk, leveldb on another), edit `$IPFS_PATH/config` and modify the `Datastore.Spec.mounts` paths. See [Kubo config docs](https://github.com/ipfs/kubo/blob/master/docs/config.md).
 
 ---
 
@@ -113,6 +149,7 @@ User=YOUR_USER
 ExecStart=/usr/local/bin/ipfs daemon
 Restart=on-failure
 RestartSec=10
+# Default: ~/.ipfs. For custom storage (step 2b), use e.g. Environment=IPFS_PATH=/var/lib/ipfs
 Environment=IPFS_PATH=/home/YOUR_USER/.ipfs
 
 [Install]
@@ -227,7 +264,7 @@ DEPLOY_SECRET=your-deploy-secret
 
 | Issue                    | Check                                                |
 |--------------------------|------------------------------------------------------|
-| `ipfs daemon` fails      | `ipfs repo fsck`; ensure enough disk space           |
+| `ipfs daemon` fails      | `ipfs repo fsck`; ensure enough disk space; check `IPFS_PATH` if using custom storage |
 | Caddy 502                | `systemctl status ipfs`; ensure Kubo is listening    |
 | Auth rejected            | Verify hash in Caddyfile; check username/password; try `basicauth` if `basic_auth` fails (older Caddy) |
 | IPNS publish fails       | Key exists: `ipfs key list -l`; key name matches      |

--- a/docs/SOVEREIGN-WORKER-SETUP.md
+++ b/docs/SOVEREIGN-WORKER-SETUP.md
@@ -1,6 +1,8 @@
 # Sovereign Worker VPS Setup
 
-Step-by-step guide to set up the **SOVEREIGN WORKER** components on a fresh Ubuntu 26.04 LTS (Resolute Raccoon) VPS:
+Step-by-step guide to set up the **SOVEREIGN WORKER** components on a fresh Ubuntu 26.04 LTS (Resolute Raccoon) VPS.
+
+> **Note:** Kubo’s HTTP RPC API (`/api/v0/...`) remains the stable interface. The Gandi gateway uses `kubo-rpc-client` (the official JS client for that API). For in-browser or in-process IPFS nodes, the IPFS team now recommends Helia (`@helia/*`).
 
 - **Kubo IPFS Node** – IPFS daemon for content storage and retrieval
 - **IPNS Key Manager** – Ed25519 keys for stable, updateable pointers (e.g. `xr-baseline-0`)
@@ -21,7 +23,8 @@ Step-by-step guide to set up the **SOVEREIGN WORKER** components on a fresh Ubun
 
 ```bash
 # Set version (check https://dist.ipfs.tech/#kubo for latest)
-KUBO_VERSION="v0.31.0"   # or v0.40.x for newest; ensure compatibility with ipfs-http-client
+# v0.40.x recommended; HTTP RPC API (/api/v0/...) is stable and used by kubo-rpc-client
+KUBO_VERSION="v0.40.1"
 
 # Download and install
 cd /tmp

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "CC-BY-3.0",
       "dependencies": {
         "dateformat": "^5.0.3",
-        "ipfs-http-client": "^60.0.1",
+        "kubo-rpc-client": "^6.1.0",
         "mime-types": "^2.1.35",
         "next": "^14.2.15",
         "react": "18.3.1",
@@ -56,15 +56,6 @@
       "integrity": "sha512-KIjt+6IfysQ4GCv66xihEitBjvhU/bixbbbFxdJ1sqCp4uJ0wuZiYBPhksZoy4lfaF0k9cwNzY5upEW/VWdw3w==",
       "license": "MIT"
     },
-    "node_modules/@chainsafe/netmask": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@chainsafe/netmask/-/netmask-2.0.0.tgz",
-      "integrity": "sha512-I3Z+6SWUoaljh3TBzCnCxjlUyN8tA+NAk5L6m9IxvCf1BENQTePzPMis97CoN/iMW1St3WN+AWCCRp+TTBRiDg==",
-      "license": "MIT",
-      "dependencies": {
-        "@chainsafe/is-ip": "^2.0.1"
-      }
-    },
     "node_modules/@dnsquery/dns-packet": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/@dnsquery/dns-packet/-/dns-packet-6.1.1.tgz",
@@ -76,15 +67,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@hapi/hoek": {
@@ -169,6 +151,63 @@
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
       "license": "MIT"
     },
+    "node_modules/@libp2p/crypto": {
+      "version": "5.1.13",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.13.tgz",
+      "integrity": "sha512-8NN9cQP3jDn+p9+QE9ByiEoZ2lemDFf/unTgiKmS3JF93ph240EUVdbCyyEgOMfykzb0okTM4gzvwfx9osJebQ==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@libp2p/interface": "^3.1.0",
+        "@noble/curves": "^2.0.1",
+        "@noble/hashes": "^2.0.1",
+        "multiformats": "^13.4.0",
+        "protons-runtime": "^5.6.0",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/@libp2p/crypto/node_modules/@noble/curves": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.0.1.tgz",
+      "integrity": "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@libp2p/crypto/node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@libp2p/crypto/node_modules/multiformats": {
+      "version": "13.4.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
+      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
+      "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/@libp2p/crypto/node_modules/uint8arrays": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
+      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
     "node_modules/@libp2p/interface": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.1.0.tgz",
@@ -181,141 +220,6 @@
         "multiformats": "^13.4.0",
         "progress-events": "^1.0.1",
         "uint8arraylist": "^2.4.8"
-      }
-    },
-    "node_modules/@libp2p/interface-connection": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-4.0.0.tgz",
-      "integrity": "sha512-6xx/NmEc84HX7QmsjSC3hHredQYjHv4Dkf4G27adAPf+qN+vnPxmQ7gaTnk243a0++DOFTbZ2gKX/15G2B6SRg==",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "@libp2p/interface-peer-id": "^2.0.0",
-        "@libp2p/interfaces": "^3.0.0",
-        "@multiformats/multiaddr": "^12.0.0",
-        "it-stream-types": "^1.0.4",
-        "uint8arraylist": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/interface-connection/node_modules/@multiformats/multiaddr": {
-      "version": "12.5.1",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.5.1.tgz",
-      "integrity": "sha512-+DDlr9LIRUS8KncI1TX/FfUn8F2dl6BIxJgshS/yFQCNB5IAF0OGzcwB39g5NLE22s4qqDePv0Qof6HdpJ/4aQ==",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "@chainsafe/is-ip": "^2.0.1",
-        "@chainsafe/netmask": "^2.0.0",
-        "@multiformats/dns": "^1.0.3",
-        "abort-error": "^1.0.1",
-        "multiformats": "^13.0.0",
-        "uint8-varint": "^2.0.1",
-        "uint8arrays": "^5.0.0"
-      }
-    },
-    "node_modules/@libp2p/interface-connection/node_modules/multiformats": {
-      "version": "13.4.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
-      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
-      "license": "Apache-2.0 OR MIT"
-    },
-    "node_modules/@libp2p/interface-connection/node_modules/uint8arrays": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
-      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "multiformats": "^13.0.0"
-      }
-    },
-    "node_modules/@libp2p/interface-keychain": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-keychain/-/interface-keychain-2.0.5.tgz",
-      "integrity": "sha512-mb7QNgn9fIvC7CaJCi06GJ+a6DN6RVT9TmEi0NmedZGATeCArPeWWG7r7IfxNVXb9cVOOE1RzV1swK0ZxEJF9Q==",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "@libp2p/interface-peer-id": "^2.0.0",
-        "multiformats": "^11.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/interface-peer-id": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.2.tgz",
-      "integrity": "sha512-9pZp9zhTDoVwzRmp0Wtxw0Yfa//Yc0GqBCJi3EznBDE6HGIAVvppR91wSh2knt/0eYg0AQj7Y35VSesUTzMCUg==",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "multiformats": "^11.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/interface-peer-info": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-info/-/interface-peer-info-1.0.10.tgz",
-      "integrity": "sha512-HQlo8NwQjMyamCHJrnILEZz+YwEOXCB2sIIw3slIrhVUYeYlTaia1R6d9umaAeLHa255Zmdm4qGH8rJLRqhCcg==",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "@libp2p/interface-peer-id": "^2.0.0",
-        "@multiformats/multiaddr": "^12.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/interface-peer-info/node_modules/@multiformats/multiaddr": {
-      "version": "12.5.1",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.5.1.tgz",
-      "integrity": "sha512-+DDlr9LIRUS8KncI1TX/FfUn8F2dl6BIxJgshS/yFQCNB5IAF0OGzcwB39g5NLE22s4qqDePv0Qof6HdpJ/4aQ==",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "@chainsafe/is-ip": "^2.0.1",
-        "@chainsafe/netmask": "^2.0.0",
-        "@multiformats/dns": "^1.0.3",
-        "abort-error": "^1.0.1",
-        "multiformats": "^13.0.0",
-        "uint8-varint": "^2.0.1",
-        "uint8arrays": "^5.0.0"
-      }
-    },
-    "node_modules/@libp2p/interface-peer-info/node_modules/multiformats": {
-      "version": "13.4.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
-      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
-      "license": "Apache-2.0 OR MIT"
-    },
-    "node_modules/@libp2p/interface-peer-info/node_modules/uint8arrays": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
-      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "multiformats": "^13.0.0"
-      }
-    },
-    "node_modules/@libp2p/interface-pubsub": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-pubsub/-/interface-pubsub-3.0.7.tgz",
-      "integrity": "sha512-+c74EVUBTfw2sx1GE/z/IjsYO6dhur+ukF0knAppeZsRQ1Kgg6K5R3eECtT28fC6dBWLjFpAvW/7QGfiDAL4RA==",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "@libp2p/interface-connection": "^4.0.0",
-        "@libp2p/interface-peer-id": "^2.0.0",
-        "@libp2p/interfaces": "^3.0.0",
-        "it-pushable": "^3.0.0",
-        "uint8arraylist": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
       }
     },
     "node_modules/@libp2p/interface/node_modules/@multiformats/multiaddr": {
@@ -343,85 +247,6 @@
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "multiformats": "^13.0.0"
-      }
-    },
-    "node_modules/@libp2p/interfaces": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.3.2.tgz",
-      "integrity": "sha512-p/M7plbrxLzuQchvNwww1Was7ZeGE2NaOFulMaZBYIihU8z3fhaV+a033OqnC/0NTX/yhfdNOG7znhYq3XoR/g==",
-      "license": "Apache-2.0 OR MIT",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/logger": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-2.1.1.tgz",
-      "integrity": "sha512-2UbzDPctg3cPupF6jrv6abQnAUTrbLybNOj0rmmrdGm1cN2HJ1o/hBu0sXuq4KF9P1h/eVRn1HIRbVIEKnEJrA==",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "@libp2p/interface-peer-id": "^2.0.2",
-        "@multiformats/multiaddr": "^12.1.3",
-        "debug": "^4.3.4",
-        "interface-datastore": "^8.2.0",
-        "multiformats": "^11.0.2"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/logger/node_modules/@multiformats/multiaddr": {
-      "version": "12.5.1",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.5.1.tgz",
-      "integrity": "sha512-+DDlr9LIRUS8KncI1TX/FfUn8F2dl6BIxJgshS/yFQCNB5IAF0OGzcwB39g5NLE22s4qqDePv0Qof6HdpJ/4aQ==",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "@chainsafe/is-ip": "^2.0.1",
-        "@chainsafe/netmask": "^2.0.0",
-        "@multiformats/dns": "^1.0.3",
-        "abort-error": "^1.0.1",
-        "multiformats": "^13.0.0",
-        "uint8-varint": "^2.0.1",
-        "uint8arrays": "^5.0.0"
-      }
-    },
-    "node_modules/@libp2p/logger/node_modules/@multiformats/multiaddr/node_modules/multiformats": {
-      "version": "13.4.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
-      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
-      "license": "Apache-2.0 OR MIT"
-    },
-    "node_modules/@libp2p/logger/node_modules/uint8arrays": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
-      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "multiformats": "^13.0.0"
-      }
-    },
-    "node_modules/@libp2p/logger/node_modules/uint8arrays/node_modules/multiformats": {
-      "version": "13.4.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
-      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
-      "license": "Apache-2.0 OR MIT"
-    },
-    "node_modules/@libp2p/peer-id": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-2.0.4.tgz",
-      "integrity": "sha512-gcOsN8Fbhj6izIK+ejiWsqiqKeJ2yWPapi/m55VjOvDa52/ptQzZszxQP8jUk93u36de92ATFXDfZR/Bi6eeUQ==",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "@libp2p/interface-peer-id": "^2.0.0",
-        "@libp2p/interfaces": "^3.2.0",
-        "multiformats": "^11.0.0",
-        "uint8arrays": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
       }
     },
     "node_modules/@lighthouse-web3/kavach": {
@@ -495,63 +320,6 @@
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@multiformats/dns/node_modules/uint8arrays": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
-      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "multiformats": "^13.0.0"
-      }
-    },
-    "node_modules/@multiformats/multiaddr": {
-      "version": "11.6.1",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.6.1.tgz",
-      "integrity": "sha512-doST0+aB7/3dGK9+U5y3mtF3jq85KGbke1QiH0KE1F5mGQ9y56mFebTeu2D9FNOm+OT6UHb8Ss8vbSnpGjeLNw==",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "@chainsafe/is-ip": "^2.0.1",
-        "dns-over-http-resolver": "^2.1.0",
-        "err-code": "^3.0.1",
-        "multiformats": "^11.0.0",
-        "uint8arrays": "^4.0.2",
-        "varint": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@multiformats/multiaddr-to-uri": {
-      "version": "9.0.8",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr-to-uri/-/multiaddr-to-uri-9.0.8.tgz",
-      "integrity": "sha512-4eiN5iEiQfy2A98BxekUfW410L/ivg0sgjYSgSqmklnrBhK+QyMz4yqgfkub8xDTXOc7O5jp4+LVyM3ZqMeWNw==",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "@multiformats/multiaddr": "^12.0.0"
-      }
-    },
-    "node_modules/@multiformats/multiaddr-to-uri/node_modules/@multiformats/multiaddr": {
-      "version": "12.5.1",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.5.1.tgz",
-      "integrity": "sha512-+DDlr9LIRUS8KncI1TX/FfUn8F2dl6BIxJgshS/yFQCNB5IAF0OGzcwB39g5NLE22s4qqDePv0Qof6HdpJ/4aQ==",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "@chainsafe/is-ip": "^2.0.1",
-        "@chainsafe/netmask": "^2.0.0",
-        "@multiformats/dns": "^1.0.3",
-        "abort-error": "^1.0.1",
-        "multiformats": "^13.0.0",
-        "uint8-varint": "^2.0.1",
-        "uint8arrays": "^5.0.0"
-      }
-    },
-    "node_modules/@multiformats/multiaddr-to-uri/node_modules/multiformats": {
-      "version": "13.4.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
-      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
-      "license": "Apache-2.0 OR MIT"
-    },
-    "node_modules/@multiformats/multiaddr-to-uri/node_modules/uint8arrays": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
       "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
@@ -740,7 +508,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -754,7 +521,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -764,7 +530,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -815,70 +580,6 @@
       "engines": {
         "node": ">=10.12.0"
       }
-    },
-    "node_modules/@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/base64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
-      }
-    },
-    "node_modules/@protobufjs/float": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/path": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/pool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
@@ -1228,16 +929,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/minimatch": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
-      "license": "MIT"
-    },
     "node_modules/@types/node": {
       "version": "20.16.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.1.tgz",
       "integrity": "sha512-zJDo7wEadFtSyNz5QITDfRcrhqDvQI1xQNQ0VoizPjM/dVAODqqIUWbJPkvsxmTI0MYRGRikcdjMPhOssnPejQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -1429,12 +1125,6 @@
         "node": "^14.14.0 || >=16.0.0"
       }
     },
-    "node_modules/abort-error": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/abort-error/-/abort-error-1.0.1.tgz",
-      "integrity": "sha512-fxqCblJiIPdSXIUrxI0PL+eJG49QdP9SQ70qtB65MVAoMr2rASlOyAbJFOylfB467F/f+5BCLJJq58RYi7mGfg==",
-      "license": "Apache-2.0 OR MIT"
-    },
     "node_modules/aes-js": {
       "version": "4.0.0-beta.5",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
@@ -1476,12 +1166,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/any-signal": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-3.0.1.tgz",
-      "integrity": "sha512-xgZgJtKEa9YmDqXodIgl7Fl1C8yNXr8w6gXjqK3LW4GcEiYT+6AQfJSE/8SPsEpLLmcvbv8YU+qet94UewHxqg==",
-      "license": "MIT"
     },
     "node_modules/arch": {
       "version": "3.0.0",
@@ -1550,6 +1234,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/bare-events": {
@@ -1645,7 +1330,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -1790,12 +1474,6 @@
         "node": ">= 12"
       }
     },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "license": "MIT"
-    },
     "node_modules/conf": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/conf/-/conf-10.2.0.tgz",
@@ -1863,16 +1541,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/dag-jose": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/dag-jose/-/dag-jose-4.0.0.tgz",
-      "integrity": "sha512-tw595L3UYoOUT9dSJPbBEG/qpRpw24kRZxa5SLRnlnr+g5L7O8oEs1d3W5TiVA1oJZbthVsf0Vi3zFN66qcEBA==",
-      "license": "(Apache-2.0 OR MIT)",
-      "dependencies": {
-        "@ipld/dag-cbor": "^9.0.0",
-        "multiformats": "^11.0.0"
-      }
-    },
     "node_modules/dateformat": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-5.0.3.tgz",
@@ -1906,23 +1574,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
       }
     },
     "node_modules/decompress-response": {
@@ -1975,18 +1626,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/dns-over-http-resolver": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.3.tgz",
-      "integrity": "sha512-zjRYFhq+CsxPAouQWzOsxNMvEN+SHisjzhX8EMxd2Y0EG3thvn6wXQgMJLnTDImkhe4jhLbOQpXtL10nALBOSA==",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "debug": "^4.3.1",
-        "native-fetch": "^4.0.2",
-        "receptacle": "^1.3.2",
-        "undici": "^5.12.0"
       }
     },
     "node_modules/dot-prop": {
@@ -2186,17 +1825,16 @@
       "license": "MIT"
     },
     "node_modules/fast-glob": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
-      "dev": true,
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
+        "micromatch": "^4.0.8"
       },
       "engines": {
         "node": ">=8.6.0"
@@ -2223,7 +1861,6 @@
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
       "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -2311,7 +1948,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -2397,7 +2033,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -2539,288 +2174,6 @@
         "kind-of": "^6.0.2"
       }
     },
-    "node_modules/interface-datastore": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.3.2.tgz",
-      "integrity": "sha512-R3NLts7pRbJKc3qFdQf+u40hK8XWc0w4Qkx3OFEstC80VoaDUABY/dXA2EJPhtNC+bsrf41Ehvqb6+pnIclyRA==",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "interface-store": "^6.0.0",
-        "uint8arrays": "^5.1.0"
-      }
-    },
-    "node_modules/interface-datastore/node_modules/multiformats": {
-      "version": "13.4.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
-      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
-      "license": "Apache-2.0 OR MIT"
-    },
-    "node_modules/interface-datastore/node_modules/uint8arrays": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
-      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "multiformats": "^13.0.0"
-      }
-    },
-    "node_modules/interface-store": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-6.0.3.tgz",
-      "integrity": "sha512-+WvfEZnFUhRwFxgz+QCQi7UC6o9AM0EHM9bpIe2Nhqb100NHCsTvNAn4eJgvgV2/tmLo1MP9nGxQKEcZTAueLA==",
-      "license": "Apache-2.0 OR MIT"
-    },
-    "node_modules/ipfs-core-types": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/ipfs-core-types/-/ipfs-core-types-0.14.1.tgz",
-      "integrity": "sha512-4ujF8NlM9bYi2I6AIqPP9wfGGX0x/gRCkMoFdOQfxxrFg6HcAdfS+0/irK8mp4e7znOHWReOHeWqCGw+dAPwsw==",
-      "deprecated": "js-IPFS has been deprecated in favour of Helia - please see https://github.com/ipfs/js-ipfs/issues/4336 for details",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "@ipld/dag-pb": "^4.0.0",
-        "@libp2p/interface-keychain": "^2.0.0",
-        "@libp2p/interface-peer-id": "^2.0.0",
-        "@libp2p/interface-peer-info": "^1.0.2",
-        "@libp2p/interface-pubsub": "^3.0.0",
-        "@multiformats/multiaddr": "^11.1.5",
-        "@types/node": "^18.0.0",
-        "interface-datastore": "^7.0.0",
-        "ipfs-unixfs": "^9.0.0",
-        "multiformats": "^11.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/ipfs-core-types/node_modules/@types/node": {
-      "version": "18.19.130",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/ipfs-core-types/node_modules/interface-datastore": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-7.0.4.tgz",
-      "integrity": "sha512-Q8LZS/jfFFHz6XyZazLTAc078SSCoa27ZPBOfobWdpDiFO7FqPA2yskitUJIhaCgxNK8C+/lMBUTBNfVIDvLiw==",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "interface-store": "^3.0.0",
-        "nanoid": "^4.0.0",
-        "uint8arrays": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/ipfs-core-types/node_modules/interface-store": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.4.tgz",
-      "integrity": "sha512-OjHUuGXbH4eXSBx1TF1tTySvjLldPLzRSYYXJwrEQI+XfH5JWYZofr0gVMV4F8XTwC+4V7jomDYkvGRmDSRKqQ==",
-      "license": "Apache-2.0 OR MIT",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/ipfs-core-types/node_modules/nanoid": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
-      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.js"
-      },
-      "engines": {
-        "node": "^14 || ^16 || >=18"
-      }
-    },
-    "node_modules/ipfs-core-types/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT"
-    },
-    "node_modules/ipfs-core-utils": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.18.1.tgz",
-      "integrity": "sha512-P7jTpdfvlyBG3JR4o+Th3QJADlmXmwMxbkjszXry6VAjfSfLIIqXsdeYPoVRkV69GFEeQozuz2k/jR+U8cUH/Q==",
-      "deprecated": "js-IPFS has been deprecated in favour of Helia - please see https://github.com/ipfs/js-ipfs/issues/4336 for details",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "@libp2p/logger": "^2.0.5",
-        "@multiformats/multiaddr": "^11.1.5",
-        "@multiformats/multiaddr-to-uri": "^9.0.1",
-        "any-signal": "^3.0.0",
-        "blob-to-it": "^2.0.0",
-        "browser-readablestream-to-it": "^2.0.0",
-        "err-code": "^3.0.1",
-        "ipfs-core-types": "^0.14.1",
-        "ipfs-unixfs": "^9.0.0",
-        "ipfs-utils": "^9.0.13",
-        "it-all": "^2.0.0",
-        "it-map": "^2.0.0",
-        "it-peekable": "^2.0.0",
-        "it-to-stream": "^1.0.0",
-        "merge-options": "^3.0.4",
-        "multiformats": "^11.0.0",
-        "nanoid": "^4.0.0",
-        "parse-duration": "^1.0.0",
-        "timeout-abort-controller": "^3.0.0",
-        "uint8arrays": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/ipfs-core-utils/node_modules/nanoid": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
-      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.js"
-      },
-      "engines": {
-        "node": "^14 || ^16 || >=18"
-      }
-    },
-    "node_modules/ipfs-http-client": {
-      "version": "60.0.1",
-      "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-60.0.1.tgz",
-      "integrity": "sha512-amwM5TNuf077J+/q27jPHfatC05vJuIbX6ZnlYLjc2QsjOCKsORNBqV3brNw7l+fPrijV1yrwEDLG3JEnKsfMw==",
-      "deprecated": "js-IPFS has been deprecated in favour of Helia - please see https://github.com/ipfs/js-ipfs/issues/4336 for details",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "@ipld/dag-cbor": "^9.0.0",
-        "@ipld/dag-json": "^10.0.0",
-        "@ipld/dag-pb": "^4.0.0",
-        "@libp2p/logger": "^2.0.5",
-        "@libp2p/peer-id": "^2.0.0",
-        "@multiformats/multiaddr": "^11.1.5",
-        "any-signal": "^3.0.0",
-        "dag-jose": "^4.0.0",
-        "err-code": "^3.0.1",
-        "ipfs-core-types": "^0.14.1",
-        "ipfs-core-utils": "^0.18.1",
-        "ipfs-utils": "^9.0.13",
-        "it-first": "^2.0.0",
-        "it-last": "^2.0.0",
-        "merge-options": "^3.0.4",
-        "multiformats": "^11.0.0",
-        "parse-duration": "^1.0.0",
-        "stream-to-it": "^0.2.2",
-        "uint8arrays": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/ipfs-unixfs": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-9.0.1.tgz",
-      "integrity": "sha512-jh2CbXyxID+v3jLml9CqMwjdSS9ZRnsGfQGGPOfem0/hT/L48xUeTPvh7qLFWkZcIMhZtG+fnS1teei8x5uGBg==",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "err-code": "^3.0.1",
-        "protobufjs": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/ipfs-utils": {
-      "version": "9.0.14",
-      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-9.0.14.tgz",
-      "integrity": "sha512-zIaiEGX18QATxgaS0/EOQNoo33W0islREABAcxXE8n7y2MGAlB+hdsxXn4J0hGZge8IqVQhW8sWIb+oJz2yEvg==",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "any-signal": "^3.0.0",
-        "browser-readablestream-to-it": "^1.0.0",
-        "buffer": "^6.0.1",
-        "electron-fetch": "^1.7.2",
-        "err-code": "^3.0.1",
-        "is-electron": "^2.2.0",
-        "iso-url": "^1.1.5",
-        "it-all": "^1.0.4",
-        "it-glob": "^1.0.1",
-        "it-to-stream": "^1.0.0",
-        "merge-options": "^3.0.4",
-        "nanoid": "^3.1.20",
-        "native-fetch": "^3.0.0",
-        "node-fetch": "^2.6.8",
-        "react-native-fetch-api": "^3.0.0",
-        "stream-to-it": "^0.2.2"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/ipfs-utils/node_modules/browser-readablestream-to-it": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-1.0.3.tgz",
-      "integrity": "sha512-+12sHB+Br8HIh6VAMVEG5r3UXCyESIgDW7kzk3BjIXa43DVqVwL7GC5TW3jeh+72dtcH99pPVpw0X8i0jt+/kw==",
-      "license": "ISC"
-    },
-    "node_modules/ipfs-utils/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/ipfs-utils/node_modules/it-all": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.6.tgz",
-      "integrity": "sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A==",
-      "license": "ISC"
-    },
-    "node_modules/ipfs-utils/node_modules/native-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-3.0.0.tgz",
-      "integrity": "sha512-G3Z7vx0IFb/FQ4JxvtqGABsOTIqRWvgQz6e+erkB+JJD6LrszQtMozEHI4EkmgZQvnGHrpLVzUWk7t4sJCIkVw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "node-fetch": "*"
-      }
-    },
     "node_modules/is-electron": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
@@ -2841,7 +2194,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -2851,7 +2203,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -2864,7 +2215,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -2917,107 +2267,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/it-all": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/it-all/-/it-all-2.0.1.tgz",
-      "integrity": "sha512-9UuJcCRZsboz+HBQTNOau80Dw+ryGaHYFP/cPYzFBJBFcfDathMYnhHk4t52en9+fcyDGPTdLB+lFc1wzQIroA==",
-      "license": "Apache-2.0 OR MIT",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/it-first": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/it-first/-/it-first-2.0.1.tgz",
-      "integrity": "sha512-noC1oEQcWZZMUwq7VWxHNLML43dM+5bviZpfmkxkXlvBe60z7AFRqpZSga9uQBo792jKv9otnn1IjA4zwgNARw==",
-      "license": "Apache-2.0 OR MIT",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/it-glob": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-1.0.2.tgz",
-      "integrity": "sha512-Ch2Dzhw4URfB9L/0ZHyY+uqOnKvBNeS/SMcRiPmJfpHiM0TsUZn+GkpcZxAoF3dJVdPm/PuIk3A4wlV7SUo23Q==",
-      "license": "ISC",
-      "dependencies": {
-        "@types/minimatch": "^3.0.4",
-        "minimatch": "^3.0.4"
-      }
-    },
-    "node_modules/it-glob/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/it-glob/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/it-last": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/it-last/-/it-last-2.0.1.tgz",
-      "integrity": "sha512-uVMedYW0wa2Cx0TAmcOCLbfuLLII7+vyURmhKa8Zovpd+aBTMsmINtsta2n364wJ5qsEDBH+akY1sUtAkaYBlg==",
-      "license": "Apache-2.0 OR MIT",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/it-map": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/it-map/-/it-map-2.0.1.tgz",
-      "integrity": "sha512-a2GcYDHiAh/eSU628xlvB56LA98luXZnniH2GlD0IdBzf15shEq9rBeb0Rg3o1SWtNILUAwqmQxEXcewGCdvmQ==",
-      "license": "Apache-2.0 OR MIT",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/it-peekable": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-2.0.1.tgz",
-      "integrity": "sha512-fJ/YTU9rHRhGJOM2hhQKKEfRM6uKB9r4yGGFLBHqp72ACC8Yi6+7/FhuBAMG8cpN6mLoj9auVX7ZJ3ul6qFpTA==",
-      "license": "Apache-2.0 OR MIT",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/it-pushable": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.2.3.tgz",
-      "integrity": "sha512-gzYnXYK8Y5t5b/BnJUr7glfQLO4U5vyb05gPx/TyTw+4Bv1zM9gFk4YsOrnulWefMewlphCjKkakFvj1y99Tcg==",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "p-defer": "^4.0.0"
-      }
-    },
-    "node_modules/it-stream-types": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-1.0.5.tgz",
-      "integrity": "sha512-I88Ka1nHgfX62e5mi5LLL+oueqz7Ltg0bUdtsUKDe9SoUqbQPf2Mp5kxDTe9pNhHQGs4pvYPAINwuZ1HAt42TA==",
-      "license": "Apache-2.0 OR MIT",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
       }
     },
     "node_modules/it-to-stream": {
@@ -3165,6 +2414,239 @@
         "node": ">=6"
       }
     },
+    "node_modules/kubo-rpc-client": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/kubo-rpc-client/-/kubo-rpc-client-6.1.0.tgz",
+      "integrity": "sha512-CH3vcqSGlEhr/HCZYQgYpXxmwIOYhNed4BQmAYmHpX7sehTC3iKK/36x7anEdRTgmV6KB66MyOk1yuhU2HqKFw==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@ipld/dag-cbor": "^9.0.0",
+        "@ipld/dag-json": "^10.0.0",
+        "@ipld/dag-pb": "^4.0.0",
+        "@libp2p/crypto": "^5.0.0",
+        "@libp2p/interface": "^3.0.2",
+        "@libp2p/logger": "^6.0.5",
+        "@libp2p/peer-id": "^6.0.3",
+        "@multiformats/multiaddr": "^13.0.1",
+        "@multiformats/multiaddr-to-uri": "^12.0.0",
+        "any-signal": "^4.1.1",
+        "blob-to-it": "^2.0.5",
+        "browser-readablestream-to-it": "^2.0.5",
+        "dag-jose": "^5.0.0",
+        "electron-fetch": "^1.9.1",
+        "err-code": "^3.0.1",
+        "ipfs-unixfs": "^12.0.0",
+        "iso-url": "^1.2.1",
+        "it-all": "^3.0.4",
+        "it-first": "^3.0.4",
+        "it-glob": "^3.0.1",
+        "it-last": "^3.0.4",
+        "it-map": "^3.0.5",
+        "it-peekable": "^3.0.3",
+        "it-to-stream": "^1.0.0",
+        "merge-options": "^3.0.4",
+        "multiformats": "^13.1.0",
+        "nanoid": "^5.0.7",
+        "parse-duration": "^2.1.2",
+        "stream-to-it": "^1.0.1",
+        "uint8arrays": "^5.0.3",
+        "wherearewe": "^2.0.1"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/@libp2p/logger": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-6.2.2.tgz",
+      "integrity": "sha512-XtanXDT+TuMuZoCK760HGV1AmJsZbwAw5AiRUxWDbsZPwAroYq64nb41AHRu9Gyc0TK9YD+p72+5+FIxbw0hzw==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@libp2p/interface": "^3.1.0",
+        "@multiformats/multiaddr": "^13.0.1",
+        "interface-datastore": "^9.0.1",
+        "multiformats": "^13.4.0",
+        "weald": "^1.1.0"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/@libp2p/peer-id": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-6.0.4.tgz",
+      "integrity": "sha512-Z3xK0lwwKn4bPg3ozEpPr1HxsRi2CxZdghOL+MXoFah/8uhJJHxHFA8A/jxtKn4BB8xkk6F8R5vKNIS05yaCYw==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@libp2p/crypto": "^5.1.13",
+        "@libp2p/interface": "^3.1.0",
+        "multiformats": "^13.4.0",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/@multiformats/multiaddr": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-13.0.1.tgz",
+      "integrity": "sha512-XToN915cnfr6Lr9EdGWakGJbPT0ghpg/850HvdC+zFX8XvpLZElwa8synCiwa8TuvKNnny6m8j8NVBNCxhIO3g==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "multiformats": "^13.0.0",
+        "uint8-varint": "^2.0.1",
+        "uint8arrays": "^5.0.0"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/@multiformats/multiaddr-to-uri": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr-to-uri/-/multiaddr-to-uri-12.0.0.tgz",
+      "integrity": "sha512-3uIEBCiy8tfzxYYBl81x1tISiNBQ7mHU4pGjippbJRoQYHzy/ZdZM/7JvTldr8pc/dzpkaNJxnsuxxlhsPOJsA==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@multiformats/multiaddr": "^13.0.0"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/any-signal": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-4.2.0.tgz",
+      "integrity": "sha512-LndMvYuAPf4rC195lk7oSFuHOYFpOszIYrNYv0gHAvz+aEhE9qPZLhmrIz5pXP2BSsPOXvsuHDXEGaiQhIh9wA==",
+      "license": "Apache-2.0 OR MIT",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/dag-jose": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/dag-jose/-/dag-jose-5.1.1.tgz",
+      "integrity": "sha512-9alfZ8Wh1XOOMel8bMpDqWsDT72ojFQCJPtwZSev9qh4f8GoCV9qrJW8jcOUhcstO8Kfm09FHGo//jqiZq3z9w==",
+      "license": "(Apache-2.0 OR MIT)",
+      "dependencies": {
+        "@ipld/dag-cbor": "^9.0.0",
+        "multiformats": "~13.1.3"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/dag-jose/node_modules/multiformats": {
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.3.tgz",
+      "integrity": "sha512-CZPi9lFZCM/+7oRolWYsvalsyWQGFo+GpdaTmjxXXomC+nP/W1Rnxb9sUgjvmNmRZ5bOPqRAl4nuK+Ydw/4tGw==",
+      "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/kubo-rpc-client/node_modules/interface-datastore": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-9.0.2.tgz",
+      "integrity": "sha512-jebn+GV/5LTDDoyicNIB4D9O0QszpPqT09Z/MpEWvf3RekjVKpXJCDguM5Au2fwIFxFDAQMZe5bSla0jMamCNg==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "interface-store": "^7.0.0",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/interface-store": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-7.0.1.tgz",
+      "integrity": "sha512-OPRRUO3Cs6Jr/t98BrJLQp1jUTPgrRH0PqFfuNoPAqd+J7ABN1tjFVjQdaOBiybYJTS/AyBSZnZVWLPvp3dW3w==",
+      "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/kubo-rpc-client/node_modules/ipfs-unixfs": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-12.0.0.tgz",
+      "integrity": "sha512-6I2YSqYCxcr/u1xdWROQU+PkmG7NAMRpwNiFffU9lmSv1I4nCXRDRy6YFH7dg8v17+gM1w+ijBK31rZGrrF5Og==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "protons-runtime": "^5.5.0",
+        "uint8arraylist": "^2.4.8"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/it-all": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-3.0.9.tgz",
+      "integrity": "sha512-fz1oJJ36ciGnu2LntAlE6SA97bFZpW7Rnt0uEc1yazzR2nKokZLr8lIRtgnpex4NsmaBcvHF+Z9krljWFy/mmg==",
+      "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/kubo-rpc-client/node_modules/it-first": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/it-first/-/it-first-3.0.9.tgz",
+      "integrity": "sha512-ZWYun273Gbl7CwiF6kK5xBtIKR56H1NoRaiJek2QzDirgen24u8XZ0Nk+jdnJSuCTPxC2ul1TuXKxu/7eK6NuA==",
+      "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/kubo-rpc-client/node_modules/it-glob": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-3.0.4.tgz",
+      "integrity": "sha512-73PbGBTK/dHp5PX4l8pkQH1ozCONP0U+PB3qMqltxPonRJQNomINE3Hn9p02m2GOu95VoeVvSZdHI2N+qub0pw==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "fast-glob": "^3.3.3"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/it-last": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/it-last/-/it-last-3.0.9.tgz",
+      "integrity": "sha512-AtfUEnGDBHBEwa1LjrpGHsJMzJAWDipD6zilvhakzJcm+BCvNX8zlX2BsHClHJLLTrsY4lY9JUjc+TQV4W7m1w==",
+      "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/kubo-rpc-client/node_modules/it-map": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/it-map/-/it-map-3.1.4.tgz",
+      "integrity": "sha512-QB9PYQdE9fUfpVFYfSxBIyvKynUCgblb143c+ktTK6ZuKSKkp7iH58uYFzagqcJ5HcqIfn1xbfaralHWam+3fg==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "it-peekable": "^3.0.0"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/it-peekable": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-3.0.8.tgz",
+      "integrity": "sha512-7IDBQKSp/dtBxXV3Fj0v3qM1jftJ9y9XrWLRIuU1X6RdKqWiN60syNwP0fiDxZD97b8SYM58dD3uklIk1TTQAw==",
+      "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/kubo-rpc-client/node_modules/it-stream-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-2.0.2.tgz",
+      "integrity": "sha512-Rz/DEZ6Byn/r9+/SBCuJhpPATDF9D+dz5pbgSUyBsCDtza6wtNATrz/jz1gDyNanC3XdLboriHnOC925bZRBww==",
+      "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/kubo-rpc-client/node_modules/multiformats": {
+      "version": "13.4.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
+      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
+      "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/kubo-rpc-client/node_modules/nanoid": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.6.tgz",
+      "integrity": "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/parse-duration": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-2.1.5.tgz",
+      "integrity": "sha512-/IX1KRw6zHDOOJrgIz++gvFASbFl7nc8GEXaLdD7d1t1x/GnrK6hh5Fgk8G3RLpkIEi4tsGj9pupGLWNg0EiJA==",
+      "license": "MIT"
+    },
+    "node_modules/kubo-rpc-client/node_modules/stream-to-it": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-1.0.1.tgz",
+      "integrity": "sha512-AqHYAYPHcmvMrcLNgncE/q0Aj/ajP6A4qGhxP6EVn7K3YTNs0bJpJyk57wc2Heb7MUL64jurvmnmui8D9kjZgA==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "it-stream-types": "^2.0.1"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/uint8arrays": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
+      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
     "node_modules/locate-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -3178,12 +2660,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/long": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
-      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "license": "Apache-2.0"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -3277,7 +2753,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -3287,7 +2762,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -3367,22 +2841,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/multiformats": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
-      "license": "Apache-2.0 OR MIT",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
     "node_modules/mute-stream": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
@@ -3406,15 +2864,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/native-fetch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-4.0.2.tgz",
-      "integrity": "sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "undici": "*"
       }
     },
     "node_modules/next": {
@@ -3491,26 +2940,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/node-gyp-build": {
       "version": "4.8.1",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.1.tgz",
@@ -3574,18 +3003,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.20"
-      }
-    },
-    "node_modules/p-defer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.1.tgz",
-      "integrity": "sha512-Mr5KC5efvAK5VUptYEIopP1bakB85k2IWXaRC0rsh1uwn1L6M0LVml8OIQ4Gudg4oyZakf7FmeRLkMMtZW1i5A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-fifo": {
@@ -3674,12 +3091,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/parse-duration": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-1.1.2.tgz",
-      "integrity": "sha512-p8EIONG8L0u7f8GFgfVlL4n8rnChTt8O5FSxgxMz2tjc9FMP199wxVKVB6IbKx11uTbKHACSvaLVIKNnoeNR/A==",
-      "license": "MIT"
-    },
     "node_modules/path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -3731,7 +3142,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -3807,28 +3217,30 @@
       "integrity": "sha512-MOzLIwhpt64KIVN64h1MwdKWiyKFNc/S6BoYKPIVUHFg0/eIEyBulhWCgn678v/4c0ri3FdGuzXymNCv02MUIw==",
       "license": "Apache-2.0 OR MIT"
     },
-    "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
+    "node_modules/protons-runtime": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.6.0.tgz",
+      "integrity": "sha512-/Kde+sB9DsMFrddJT/UZWe6XqvL7SL5dbag/DBCElFKhkwDj7XKt53S+mzLyaDP5OqS0wXjV5SA572uWDaT0Hg==",
+      "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
+        "uint8-varint": "^2.0.2",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^5.0.1"
+      }
+    },
+    "node_modules/protons-runtime/node_modules/multiformats": {
+      "version": "13.4.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
+      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
+      "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/protons-runtime/node_modules/uint8arrays": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
+      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "multiformats": "^13.0.0"
       }
     },
     "node_modules/pvtsutils": {
@@ -3855,7 +3267,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3910,24 +3321,6 @@
         "react": "^18.3.1"
       }
     },
-    "node_modules/react-native-fetch-api": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/react-native-fetch-api/-/react-native-fetch-api-3.0.0.tgz",
-      "integrity": "sha512-g2rtqPjdroaboDKTsJCTlcmtw54E25OjyaunUP0anOZn4Fuo2IKs8BVfe02zVggA/UysbmfSnRJIqtNkAgggNA==",
-      "license": "MIT",
-      "dependencies": {
-        "p-defer": "^3.0.0"
-      }
-    },
-    "node_modules/react-native-fetch-api/node_modules/p-defer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
-      "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/read": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
@@ -3953,15 +3346,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/receptacle": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/receptacle/-/receptacle-1.3.2.tgz",
-      "integrity": "sha512-HrsFvqZZheusncQRiEE7GatOAETrARKV/lnfYicIm8lbvp/JQOdADOfhjBd2DajvoszEyxSM6RlAAIZgEoeu/A==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
       }
     },
     "node_modules/recursive-fs": {
@@ -4018,17 +3402,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/retimer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/retimer/-/retimer-3.0.0.tgz",
-      "integrity": "sha512-WKE0j11Pa0ZJI5YIk0nflGI7SQsfl2ljihVy7ogh7DeQSeYAUi0ubZ/yEueGtDfUPk6GH5LRw1hBdLq4IwUBWA==",
-      "license": "MIT"
-    },
     "node_modules/reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -4039,7 +3416,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4266,15 +3642,6 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/stream-to-it": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-0.2.4.tgz",
-      "integrity": "sha512-4vEbkSs83OahpmBybNJXlJd7d6/RxzkkSdT3I0mnGt79Xd2Kk+e1JqbvAvsQfCeKj3aKb0QIWkyK3/n0j506vQ==",
-      "license": "MIT",
-      "dependencies": {
-        "get-iterator": "^1.0.2"
-      }
-    },
     "node_modules/streamsearch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
@@ -4378,6 +3745,18 @@
         }
       }
     },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/tar-stream": {
       "version": "3.1.7",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
@@ -4407,20 +3786,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/timeout-abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/timeout-abort-controller/-/timeout-abort-controller-3.0.0.tgz",
-      "integrity": "sha512-O3e+2B8BKrQxU2YRyEjC/2yFdb33slI22WRdUaDx6rvysfi9anloNZyR2q0l6LnePo5qH7gSM7uZtvvwZbc2yA==",
-      "license": "MIT",
-      "dependencies": {
-        "retimer": "^3.0.0"
-      }
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -4446,12 +3815,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
       }
-    },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -4535,25 +3898,6 @@
         "multiformats": "^13.0.0"
       }
     },
-    "node_modules/uint8arrays": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.10.tgz",
-      "integrity": "sha512-AnJNUGGDJAgFw/eWu/Xb9zrVKEGlwJJCaeInlf3BkecE/zcTobk5YXYIPNQJO1q5Hh1QZrQQHf0JvcHqz2hqoA==",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "multiformats": "^12.0.1"
-      }
-    },
-    "node_modules/uint8arrays/node_modules/multiformats": {
-      "version": "12.1.3",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
-      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
-      "license": "Apache-2.0 OR MIT",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
     "node_modules/unbzip2-stream": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
@@ -4565,22 +3909,11 @@
         "through": "^2.3.8"
       }
     },
-    "node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-      "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.0"
-      }
-    },
     "node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/universalify": {
@@ -4605,11 +3938,24 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
-    "node_modules/varint": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
-      "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==",
-      "license": "MIT"
+    "node_modules/weald": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/weald/-/weald-1.1.1.tgz",
+      "integrity": "sha512-PaEQShzMCz8J/AD2N3dJMc1hTZWkJeLKS2NMeiVkV5KDHwgZe7qXLEzyodsT/SODxWDdXJJqocuwf3kHzcXhSQ==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "ms": "^3.0.0-canary.1",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/weald/node_modules/ms": {
+      "version": "3.0.0-canary.202508261828",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-3.0.0-canary.202508261828.tgz",
+      "integrity": "sha512-NotsCoUCIUkojWCzQff4ttdCfIPoA1UGZsyQbi7KmqkNRfKCrvga8JJi2PknHymHOuor0cJSn/ylj52Cbt2IrQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/webcrypto-core": {
       "version": "1.8.1",
@@ -4625,20 +3971,17 @@
         "tslib": "^2.7.0"
       }
     },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
+    "node_modules/wherearewe": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/wherearewe/-/wherearewe-2.0.1.tgz",
+      "integrity": "sha512-XUguZbDxCA2wBn2LoFtcEhXL6AXo+hVjGonwhSTTTU9SzbWG8Xu3onNIpzf9j/mYUcJQ0f+m37SzG77G851uFw==",
+      "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
+        "is-electron": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "repository": "Real-Currents/www",
   "dependencies": {
     "dateformat": "^5.0.3",
-    "ipfs-http-client": "^60.0.1",
+    "kubo-rpc-client": "^6.1.0",
     "mime-types": "^2.1.35",
     "next": "^14.2.15",
     "react": "18.3.1",

--- a/server.js
+++ b/server.js
@@ -1,14 +1,14 @@
 import { createServer } from 'http';
 import { parse } from 'url';
 import next from 'next';
-import { create } from 'ipfs-http-client';
+import { create } from 'kubo-rpc-client';
 import mime from 'mime-types';
 
 const dev = process.env.NODE_ENV !== 'production';
 const app = next({ dev });
 const handle = app.getRequestHandler();
 
-// IPFS Client - connects to your Worker node via Caddy
+// Kubo RPC Client - connects to Worker node via Caddy (Kubo HTTP RPC API /api/v0/...)
 // When IPFS_NODE_HOST is not set (e.g. local dev), IPFS/IPNS routes will return 503
 let ipfs = null;
 if (process.env.IPFS_NODE_HOST && process.env.IPFS_USER && process.env.IPFS_PASS) {
@@ -16,6 +16,7 @@ if (process.env.IPFS_NODE_HOST && process.env.IPFS_USER && process.env.IPFS_PASS
     host: process.env.IPFS_NODE_HOST,
     port: 443,
     protocol: 'https',
+    path: 'api/v0',
     headers: {
       authorization: `Basic ${Buffer.from(
         `${process.env.IPFS_USER}:${process.env.IPFS_PASS}`


### PR DESCRIPTION
- Replace deprecated ipfs-http-client with kubo-rpc-client (official Kubo RPC API client)
- Update SOVEREIGN-WORKER-SETUP.md: Kubo v0.40.1, note on Kubo/Helia split
- Update IPFS-INTEGRATION.md dependency list

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Switching the IPFS/Kubo client library changes how the gateway and deploy/IPNS publish endpoints talk to the Worker node, so misconfiguration (notably the `/api/v0` path) could break IPFS/IPNS serving or deployments. Docs and lockfile churn are low risk, but runtime integration changes warrant a careful smoke test against a real Kubo daemon.
> 
> **Overview**
> Replaces the deprecated `ipfs-http-client` with `kubo-rpc-client` across the Node gateway, updating `server.js` to construct the client against Kubo’s HTTP RPC API (including explicitly targeting `api/v0`).
> 
> Updates operational docs (`IPFS-INTEGRATION.md`, `SOVEREIGN-WORKER-SETUP.md`) to reflect the new client, bump the recommended Kubo version, and add guidance for optional custom `IPFS_PATH` storage. Dependency manifests (`package.json`/`package-lock.json`) are updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56c59c73ddd39b7134211b8db418a50d6b0b27c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->